### PR TITLE
default generic span name to {component}:{docName}

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AbstractProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AbstractProcessorComponent.java
@@ -51,6 +51,11 @@ public abstract class AbstractProcessorComponent implements ProcessorComponent {
         .withTransactionId(getTransactionId(notification));
   }
 
+  protected String getDefaultSpanName(EnrichedServerNotification notification) {
+    return notification.getComponent().getIdentifier().getName().concat(":")
+        .concat(getComponentDocName(notification));
+  }
+
   protected String getTransactionId(EnrichedServerNotification notification) {
     return notification.getEvent().getCorrelationId();
   }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/GenericProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/GenericProcessorComponent.java
@@ -16,7 +16,7 @@ public class GenericProcessorComponent extends AbstractProcessorComponent {
     Map<String, String> tags = new HashMap<>(getProcessorCommonTags(notification));
     return TraceComponent.newBuilder(notification.getComponent().getLocation().getLocation())
         .withLocation(notification.getComponent().getLocation().getLocation())
-        .withSpanName(notification.getComponent().getIdentifier().getName())
+        .withSpanName(getDefaultSpanName(notification))
         .withTags(tags)
         .withTransactionId(getTransactionId(notification))
         .build();

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorEnabled.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorEnabled.java
@@ -24,9 +24,9 @@ public class MuleOpenTelemetryProcessorEnabled extends AbstractMuleArtifactTrace
         .as("Spans for listener and processors")
         .hasSize(4)
         .extracting("spanName", "spanKind")
-        .containsOnly(tuple("'logger'", "INTERNAL"),
-            tuple("'set-payload'", "INTERNAL"),
-            tuple("'logger'", "INTERNAL"),
+        .containsOnly(tuple("'logger:Logger'", "INTERNAL"),
+            tuple("'set-payload:Set Payload'", "INTERNAL"),
+            tuple("'logger:Logger'", "INTERNAL"),
             tuple("'/test'", "SERVER"));
   }
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/test/util/Span.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/test/util/Span.java
@@ -53,14 +53,28 @@ public class Span {
         .toString();
   }
 
+  /**
+   * Parse the Span String into @{@link Span} object. Parsing is based on logic
+   * in @{@link io.opentelemetry.exporter.logging.LoggingSpanExporter#export(Collection)}
+   * class.
+   * 
+   * @param spanString
+   * @return
+   */
   public static Span fromString(String spanString) {
-    String[] spaceSplit = spanString.split(" ");
+
     Span span = new Span();
     span.rawString = spanString;
-    span.spanName = spaceSplit[0];
-    span.traceId = spaceSplit[2];
-    span.spanId = spaceSplit[3];
-    span.spanKind = spaceSplit[4];
+    String spanEndSign = "' : ";
+    span.spanName = spanString.substring(0, spanString.indexOf(spanEndSign) + 1).trim();
+
+    String idString = spanString
+        .substring(spanString.indexOf(spanEndSign) + spanEndSign.length(), spanString.indexOf("[tracer:"))
+        .trim();
+    String[] idParts = idString.split(" ");
+    span.traceId = idParts[0];
+    span.spanId = idParts[1];
+    span.spanKind = idParts[2];
 
     String attrMapKey = "AttributesMap{";
     String attrMap = spanString.substring(spanString.indexOf(attrMapKey) + attrMapKey.length(),


### PR DESCRIPTION
Fixes #5.

Generic processor span names, if enabled, will have {component}:{docName} as a span name. For example, `set-payload:Set Payload`, `logger:Logger`.