### PR TITLE
generic exporter and properties support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,13 +38,7 @@ To use this extension, add following dependency to your mule application project
 
 === Auto Configuration
 Extension uses OpenTelemetry's autoconfigured SDK. In this mode, SDK will configure itself based on the environment variables.
-Supported environment variable details can be seen on [open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure).
-
-==== Exporters
-Extension contains all dependencies needed to send traces to an OpenTelemetry Collector endpoint i.e. when `otel.traces.exporter` is set to `otlp`. Note that `otlp` is the default exporter if the variable is not set.
-
-For all other exporters, application must add additional required dependencies. See [sdk-extensions/autoconfigure#exporters](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#exporters) for details.
-
+Supported environment variable details can be seen on https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure[open-telemetry/opentelemetry-java].
 
 === Extension Configuration
 Extension allows to configure some resource and exporter attributes at individual application level. This configuration is minimal required to successfully send traces to OpenTelemetry collector.
@@ -53,12 +47,15 @@ Following example shows an OpenTelemetry Config with OTLP Exporter configured -
 
 [source,xml]
 ----
-  <opentelemetry:config name="OpenTelemetry_Config" doc:name="OpenTelemetry Config" serviceName="api-app-1" spanAllProcessors="true">
+<opentelemetry:config name="OpenTelemetry_Config" doc:name="OpenTelemetry Config" doc:id="91477cb5-36f7-48ad-90b7-c339af87b408" serviceName="api-app-1">
     <opentelemetry:exporter >
         <opentelemetry:otlp-exporter collectorEndpoint="http://localhost:55681/v1" protocol="HTTP_PROTOBUF" >
             <opentelemetry:headers >
                 <opentelemetry:header key="testHeader" value="testHeaderValue" />
             </opentelemetry:headers>
+            <opentelemetry:config-properties >
+                <opentelemetry:config-property key="otel.logs.exporter" value="otlp" />
+            </opentelemetry:config-properties>
         </opentelemetry:otlp-exporter>
     </opentelemetry:exporter>
     <opentelemetry:resource-attributes >
@@ -67,6 +64,45 @@ Following example shows an OpenTelemetry Config with OTLP Exporter configured -
 </opentelemetry:config>
 ----
 
+When additional properties from SDK Auto-configuration are needed for exporter, `config-properties` can be used to add those. Environment and System properties will still override those entries.
+
+
+=== Exporters
+
+Extension supports following exporter configurations -
+
+- OTLP Exporter
+- Logging Exporter
+- Generic Exporter
+
+==== OTLP Exporter
+Extension contains all dependencies needed to send traces to an OpenTelemetry Collector endpoint i.e. when `otel.traces.exporter` is set to `otlp`. Note that `otlp` is the default exporter if the variable is not set.
+
+==== Logging Exporter
+Extension contains all dependencies needed to send traces to a `java.util.Logger` instance i.e. when `otel.traces.exporter` is set to `logging`.
+
+==== Generic Exporter
+This generic exporter allows to configure any other exporters supported by https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#exporters[sdk-extensions/autoconfigure#exporters].
+
+WARNING: Required external dependencies must be added to the application.
+
+Following example shows possible configuration for to send traces to Zipkin. This will require Zipkin dependencies to be added to the application.
+
+[source,xml]
+----
+<opentelemetry:config name="OpenTelemetry_Generic" doc:name="OpenTelemetry Config" serviceName="app1" >
+    <opentelemetry:exporter >
+        <opentelemetry:generic-exporter >
+            <opentelemetry:config-properties >
+                <opentelemetry:config-property key="otel.traces.exporter" value="zipkin" />
+                <opentelemetry:config-property key="otel.exporter.zipkin.endpoint" value="http://localhost:9411/api/v2/spans" />
+            </opentelemetry:config-properties>
+        </opentelemetry:generic-exporter>
+    </opentelemetry:exporter>
+</opentelemetry:config>
+----
+
+== Trace Spans
 Trace spans are created for only following mule components -
 
 - flows
@@ -141,9 +177,10 @@ As described above in context extraction, if the target endpoint is another mule
 === Local Collector with Zipkin
 
 `src/test/docker` contains two files:
+
 - docker-compose.yml: This config file configures two services -
-- OpenTelemetry Collector: [Collector](https://opentelemetry.io/docs/collector/getting-started/#docker) service to receive traces.
-- OpenZipkin: [Zipkin](https://zipkin.io/) as a tracing backend.
+- OpenTelemetry Collector: https://opentelemetry.io/docs/collector/getting-started/#docker[Collector] service to receive traces.
+- OpenZipkin: https://zipkin.io/[Zipkin] as a tracing backend.
 - otel-local-config.yml: Collector configuration file. Collector service uses this and forwards traces to zipkin.
 
 === Local configuration
@@ -176,7 +213,7 @@ mvn build-helper:parse-version versions:set -DnewVersion='${parsedVersion.majorV
 == TODO
 - Extension Features
   - OpenTelemetry SDK
-    - [ ] Create Mule Environment [Resource](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#resource-provider-spi)
+    - [ ] Create Mule Environment https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#resource-provider-spi[Resource]
   - [x] Mule SDK Based OpenTelemetry Connection Management
   - Configuration
     - [x] Allow setting service name on configuration

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.avioconsulting</groupId>
 	<artifactId>mule-open-telemetry-module</artifactId>
-	<version>0.0.34</version>
+	<version>0.0.43</version>
 	<packaging>mule-extension</packaging>
 	<name>OpenTelemetry Extension</name>
 

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/AbstractExporter.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/AbstractExporter.java
@@ -1,0 +1,38 @@
+package com.avioconsulting.mule.opentelemetry.api.config.exporter;
+
+import org.mule.runtime.extension.api.annotation.param.NullSafe;
+import org.mule.runtime.extension.api.annotation.param.Optional;
+import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.extension.api.annotation.param.display.Summary;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.avioconsulting.mule.opentelemetry.api.config.exporter.OpenTelemetryExporter.*;
+
+public abstract class AbstractExporter implements OpenTelemetryExporter {
+
+  @Parameter
+  @NullSafe
+  @Optional
+  @Summary("Additional Configuration properties for Exporter. System or Environment Variables will override this configuration.")
+  private Map<String, String> configProperties = new HashMap<>();
+
+  public Map<String, String> getConfigProperties() {
+    return configProperties;
+  }
+
+  public void setConfigProperties(Map<String, String> configProperties) {
+    this.configProperties = configProperties;
+  }
+
+  @Override
+  public Map<String, String> getExporterProperties() {
+    Map<String, String> config = new HashMap<>();
+    config.put(OTEL_TRACES_EXPORTER_KEY, "none");
+    config.put(OTEL_METRICS_EXPORTER_KEY, "none");
+    config.put(OTEL_LOGS_EXPORTER_KEY, "none");
+    config.putAll(getConfigProperties());
+    return config;
+  }
+}

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/GenericExporter.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/GenericExporter.java
@@ -1,0 +1,13 @@
+package com.avioconsulting.mule.opentelemetry.api.config.exporter;
+
+import org.mule.runtime.extension.api.annotation.param.display.Summary;
+
+/**
+ * A generic exporter that can purely be configured using config properties,
+ * environment variables, or system properties as described in SDK
+ * auto-configuration.
+ */
+@Summary("A generic exporter that can purely be configured using config properties, environment variables, or system properties as described in SDK auto-configuration. External dependencies may need to be added.")
+public class GenericExporter extends AbstractExporter {
+
+}

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/LoggingExporter.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/LoggingExporter.java
@@ -1,16 +1,15 @@
 package com.avioconsulting.mule.opentelemetry.api.config.exporter;
 
-import com.avioconsulting.mule.opentelemetry.api.config.KeyValuePair;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.display.Summary;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
-public class LoggingExporter implements OpenTelemetryExporter {
+public class LoggingExporter extends AbstractExporter {
 
+  public static final String OTEL_EXPORTER_LOGGING_PREFIX_KEY = "otel.exporter.logging.prefix";
   @Parameter
   @Optional
   @Summary("An optional string printed in front of the span name and attributes")
@@ -21,12 +20,10 @@ public class LoggingExporter implements OpenTelemetryExporter {
   }
 
   @Override
-  public Map<String, String> getConfigProperties() {
-    Map<String, String> config = new HashMap<>();
-    config.put("otel.traces.exporter", "logging");
-    config.put("otel.metrics.exporter", "logging");
-    config.put("otel.logs.exporter", "logging");
-    config.put("otel.exporter.logging.prefix", getLogPrefix());
+  public Map<String, String> getExporterProperties() {
+    Map<String, String> config = super.getExporterProperties();
+    config.put(OpenTelemetryExporter.OTEL_TRACES_EXPORTER_KEY, "logging");
+    config.put(OTEL_EXPORTER_LOGGING_PREFIX_KEY, getLogPrefix());
     return Collections.unmodifiableMap(config);
   }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OpenTelemetryExporter.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OpenTelemetryExporter.java
@@ -3,5 +3,9 @@ package com.avioconsulting.mule.opentelemetry.api.config.exporter;
 import java.util.Map;
 
 public interface OpenTelemetryExporter {
-  Map<String, String> getConfigProperties();
+  String OTEL_TRACES_EXPORTER_KEY = "otel.traces.exporter";
+  String OTEL_METRICS_EXPORTER_KEY = "otel.metrics.exporter";
+  String OTEL_LOGS_EXPORTER_KEY = "otel.logs.exporter";
+
+  Map<String, String> getExporterProperties();
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporter.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporter.java
@@ -13,7 +13,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class OtlpExporter implements OpenTelemetryExporter {
+public class OtlpExporter extends AbstractExporter {
 
   @Parameter
   @Optional
@@ -43,21 +43,21 @@ public class OtlpExporter implements OpenTelemetryExporter {
     return collectorEndpoint;
   }
 
-  public Map<String, String> getConfigProperties() {
-    Map<String, String> config = new HashMap<>();
-    config.put("otel.traces.exporter", "otlp");
+  public Map<String, String> getExporterProperties() {
+    Map<String, String> config = super.getExporterProperties();
+    config.put(OTEL_TRACES_EXPORTER_KEY, "otlp");
     config.put("otel.exporter.otlp.protocol", protocol.getValue());
     config.put("otel.exporter.otlp.endpoint", getCollectorEndpoint());
-    config.put("otel.exporter.otlp.traces.endpoint", getSingalEndpoint("traces"));
+    config.put("otel.exporter.otlp.traces.endpoint", getSignalEndpoint("traces"));
     config.put("otel.exporter.otlp.headers", KeyValuePair.commaSeparatedList(getHeaders()));
     return Collections.unmodifiableMap(config);
   }
 
-  private String getSingalEndpoint(String singal) {
+  private String getSignalEndpoint(String signal) {
     String endpoint = getCollectorEndpoint();
     if (!endpoint.endsWith("/"))
       endpoint = endpoint.concat("/");
-    return endpoint.concat(singal);
+    return endpoint.concat(signal);
   }
 
   @Override

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryExtension.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryExtension.java
@@ -1,5 +1,6 @@
 package com.avioconsulting.mule.opentelemetry.internal;
 
+import com.avioconsulting.mule.opentelemetry.api.config.exporter.GenericExporter;
 import com.avioconsulting.mule.opentelemetry.api.config.exporter.LoggingExporter;
 import com.avioconsulting.mule.opentelemetry.api.config.exporter.OpenTelemetryExporter;
 import com.avioconsulting.mule.opentelemetry.api.config.exporter.OtlpExporter;
@@ -12,6 +13,7 @@ import org.mule.runtime.extension.api.annotation.dsl.xml.Xml;
 @Xml(prefix = "opentelemetry")
 @Extension(name = "OpenTelemetry")
 @Configurations(OpenTelemetryExtensionConfiguration.class)
-@SubTypeMapping(baseType = OpenTelemetryExporter.class, subTypes = { OtlpExporter.class, LoggingExporter.class })
+@SubTypeMapping(baseType = OpenTelemetryExporter.class, subTypes = { OtlpExporter.class, LoggingExporter.class,
+    GenericExporter.class })
 public class OpenTelemetryExtension {
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
@@ -52,7 +52,7 @@ public class OpenTelemetryConnection implements TraceContextHandler {
                 .commaSeparatedList(openTelemetryConfigWrapper.getResource().getResourceAttributes()));
       }
       if (openTelemetryConfigWrapper.getExporter() != null) {
-        configMap.putAll(openTelemetryConfigWrapper.getExporter().getConfigProperties());
+        configMap.putAll(openTelemetryConfigWrapper.getExporter().getExporterProperties());
       }
       builder.addPropertiesSupplier(() -> Collections.unmodifiableMap(configMap));
     }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/GenericExporterTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/GenericExporterTest.java
@@ -1,0 +1,30 @@
+package com.avioconsulting.mule.opentelemetry.api.config.exporter;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static com.avioconsulting.mule.opentelemetry.api.config.exporter.OpenTelemetryExporter.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericExporterTest {
+
+  @Test
+  public void testGenericExporter_WithNoConfigProperties() {
+    GenericExporter genericExporter = new GenericExporter();
+    assertThat(genericExporter.getExporterProperties())
+        .containsEntry(OTEL_TRACES_EXPORTER_KEY, "none")
+        .containsEntry(OTEL_METRICS_EXPORTER_KEY, "none")
+        .containsEntry(OTEL_LOGS_EXPORTER_KEY, "none");
+  }
+
+  @Test
+  public void testGenericExporter_WithConfigProperties() {
+    GenericExporter genericExporter = new GenericExporter();
+    genericExporter.setConfigProperties(Collections.singletonMap(OTEL_TRACES_EXPORTER_KEY, "zipkin"));
+    assertThat(genericExporter.getExporterProperties())
+        .containsEntry(OTEL_TRACES_EXPORTER_KEY, "zipkin")
+        .containsEntry(OTEL_METRICS_EXPORTER_KEY, "none")
+        .containsEntry(OTEL_LOGS_EXPORTER_KEY, "none");
+  }
+}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/LoggingExporterTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/LoggingExporterTest.java
@@ -1,0 +1,22 @@
+package com.avioconsulting.mule.opentelemetry.api.config.exporter;
+
+import org.junit.Test;
+
+import static com.avioconsulting.mule.opentelemetry.api.config.exporter.LoggingExporter.OTEL_EXPORTER_LOGGING_PREFIX_KEY;
+import static com.avioconsulting.mule.opentelemetry.api.config.exporter.LoggingExporter.OTEL_LOGS_EXPORTER_KEY;
+import static com.avioconsulting.mule.opentelemetry.api.config.exporter.OpenTelemetryExporter.OTEL_METRICS_EXPORTER_KEY;
+import static com.avioconsulting.mule.opentelemetry.api.config.exporter.OpenTelemetryExporter.OTEL_TRACES_EXPORTER_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LoggingExporterTest {
+
+  @Test
+  public void getExporterProperties() {
+    LoggingExporter exporter = new LoggingExporter();
+    assertThat(exporter.getExporterProperties())
+        .containsEntry(OTEL_TRACES_EXPORTER_KEY, "logging")
+        .containsEntry(OTEL_METRICS_EXPORTER_KEY, "none")
+        .containsEntry(OTEL_LOGS_EXPORTER_KEY, "none")
+        .containsEntry(OTEL_EXPORTER_LOGGING_PREFIX_KEY, null);
+  }
+}


### PR DESCRIPTION
Closes #10 by adding new `config-properties` for all exporters - 

```
<opentelemetry:config-properties >
	<opentelemetry:config-property key="some.key" value="some.value" />
</opentelemetry:config-properties>
```

Also, adds a new Generic Exporter that is configured using `config-properties` only. See Readme updates.

```
<opentelemetry:exporter >
	<opentelemetry:generic-exporter >
		<opentelemetry:config-properties >
			<opentelemetry:config-property key="otel.traces.exporter" value="zipkin" />
			<opentelemetry:config-property key="otel.exporter.zipkin.endpoint" value="http://localhost:9411/api/v2/spans" />
		</opentelemetry:config-properties>
	</opentelemetry:generic-exporter>
</opentelemetry:exporter>
```