### PR TITLE
Anypoint MQ Span attribute and operation updates

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
@@ -29,9 +29,4 @@ public class SemanticAttributes {
   public static final AttributeKey<String> MULE_APP_DOMAIN = AttributeKey.stringKey("mule.app.domain");
   public static final AttributeKey<String> MULE_APP_FULL_DOMAIN = AttributeKey.stringKey("mule.app.fullDomain");
 
-  public static final AttributeKey<String> ANYPOINT_MQ_URL = AttributeKey.stringKey("anypoint.mq.url");
-  public static final AttributeKey<String> ANYPOINT_MQ_CLIENT_ID = AttributeKey.stringKey("anypoint.mq.clientId");
-  public static final AttributeKey<String> ANYPOINT_MQ_DESTINATION = AttributeKey
-      .stringKey("anypoint.mq.destination");
-  public static final AttributeKey<String> ANYPOINT_MQ_MESSAGE_ID = AttributeKey.stringKey("anypoint.mq.messageId");
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessor.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessor.java
@@ -129,7 +129,7 @@ public class MuleNotificationProcessor {
           .getSourceTraceComponent(notification, openTelemetryConnection).get();
       SpanBuilder spanBuilder = openTelemetryConnection
           .spanBuilder(traceComponent.getSpanName())
-          .setSpanKind(SpanKind.SERVER)
+          .setSpanKind(traceComponent.getSpanKind())
           .setParent(traceComponent.getContext())
           .setStartTimestamp(Instant.ofEpochMilli(notification.getTimestamp()));
       traceComponent.getTags().forEach(spanBuilder::setAttribute);

--- a/src/test/resources/anypoint-mq-flows.xml
+++ b/src/test/resources/anypoint-mq-flows.xml
@@ -19,6 +19,10 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
 			<anypoint-mq:properties ><![CDATA[#[vars.OTEL_TRACE_CONTEXT]]]></anypoint-mq:properties>
 		</anypoint-mq:publish>
 	</flow>
+	<flow name="anypoint-mq-consume-operation" doc:id="8ac5b3aa-e00d-44c5-9114-6e8b1a593e25" >
+		<set-payload value="#[output json --- {id: 1}]" doc:name="Set Payload" doc:id="f9f160b9-4325-4c52-8ac8-a94eb3bd2045" />
+		<anypoint-mq:consume doc:name="Consume" config-ref="Anypoint_MQ_Config" destination="otel-test-queue-1" pollingTime="0" acknowledgementMode="MANUAL"/>
+	</flow>
 	<flow name="anypoint-mq-flowsFlow" doc:id="63b1f87a-16ba-4d59-a17e-5cdf9f278763" maxConcurrency="1">
 		<anypoint-mq:subscriber doc:name="Subscriber" doc:id="7f4b30f5-2be5-4678-aedd-8ca0752aa664" config-ref="Anypoint_MQ_Config" destination="otel-test-queue-1" acknowledgementMode="MANUAL" acknowledgementTimeout="1" acknowledgementTimeoutUnit="MINUTES">
 			<anypoint-mq:subscriber-type >


### PR DESCRIPTION
1. Closes #32 - Sets Anypoint MQ info to Messaging Attributes.
2. Makes Anypoint MQ Consume operation to generate CONSUMER spans.