### PR TITLE
Improving HTTP tags and Span status

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/processor/ProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/processor/ProcessorComponent.java
@@ -45,7 +45,20 @@ public interface ProcessorComponent {
    * @{@link TraceContextHandler} to help extract OpenTelemetry context
    * @return @{@link Optional<TraceComponent>}
    */
-  default Optional<TraceComponent> getSourceTraceComponent(EnrichedServerNotification notification,
+  default Optional<TraceComponent> getSourceStartTraceComponent(EnrichedServerNotification notification,
+      TraceContextHandler traceContextHandler) {
+    return Optional.empty();
+  }
+
+  /**
+   * For flows with a source component, this method can allow processor components
+   * to build source specific traces.
+   *
+   * @param notification
+   * @param traceContextHandler
+   * @return
+   */
+  default Optional<TraceComponent> getSourceEndTraceComponent(EnrichedServerNotification notification,
       TraceContextHandler traceContextHandler) {
     return Optional.empty();
   }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/DelegatedLoggingSpanExporterProvider.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/DelegatedLoggingSpanExporterProvider.java
@@ -49,6 +49,7 @@ public class DelegatedLoggingSpanExporterProvider implements ConfigurableSpanExp
         span.setSpanId(spanData.getSpanId());
         span.setSpanKind(spanData.getKind().toString());
         span.setTraceId(spanData.getTraceId());
+        span.setSpanStatus(spanData.getStatus().getStatusCode().name());
         Map<String, Object> attributes = new HashMap<>();
         spanData.getAttributes().forEach((key, value) -> attributes.put(key.getKey(), value));
         span.setAttributes(attributes);
@@ -78,8 +79,16 @@ public class DelegatedLoggingSpanExporterProvider implements ConfigurableSpanExp
     private String traceId;
     private String spanId;
     private String spanKind;
-    private String rawString;
+    private String spanStatus;
     private Map<String, Object> attributes;
+
+    public String getSpanStatus() {
+      return spanStatus;
+    }
+
+    public void setSpanStatus(String spanStatus) {
+      this.spanStatus = spanStatus;
+    }
 
     public void setSpanName(String spanName) {
       this.spanName = spanName;
@@ -95,10 +104,6 @@ public class DelegatedLoggingSpanExporterProvider implements ConfigurableSpanExp
 
     public void setSpanKind(String spanKind) {
       this.spanKind = spanKind;
-    }
-
-    public void setRawString(String rawString) {
-      this.rawString = rawString;
     }
 
     public void setAttributes(Map<String, Object> attributes) {
@@ -121,10 +126,6 @@ public class DelegatedLoggingSpanExporterProvider implements ConfigurableSpanExp
       return spanKind;
     }
 
-    public String getRawString() {
-      return rawString;
-    }
-
     public Map<String, Object> getAttributes() {
       return attributes;
     }
@@ -136,7 +137,7 @@ public class DelegatedLoggingSpanExporterProvider implements ConfigurableSpanExp
           ", traceId='" + traceId + '\'' +
           ", spanId='" + spanId + '\'' +
           ", spanKind='" + spanKind + '\'' +
-          ", rawString='" + rawString + '\'' +
+          ", spanStatus='" + spanStatus + '\'' +
           ", attributes=" + attributes +
           '}';
     }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AbstractProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AbstractProcessorComponent.java
@@ -68,12 +68,17 @@ public abstract class AbstractProcessorComponent implements ProcessorComponent {
 
   @Override
   public TraceComponent getEndTraceComponent(EnrichedServerNotification notification) {
+    return getTraceComponentBuilderFor(notification)
+        .build();
+  }
+
+  protected TraceComponent.Builder getTraceComponentBuilderFor(EnrichedServerNotification notification) {
     return TraceComponent.newBuilder(notification.getResourceIdentifier())
         .withTransactionId(getTransactionId(notification))
         .withLocation(notification.getComponent().getLocation().getLocation())
+        .withTags(new HashMap<>())
         .withErrorMessage(
-            notification.getEvent().getError().map(Error::getDescription).orElse(null))
-        .build();
+            notification.getEvent().getError().map(Error::getDescription).orElse(null));
   }
 
   protected TraceComponent.Builder getBaseTraceComponent(

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AnypointMQProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AnypointMQProcessorComponent.java
@@ -84,7 +84,7 @@ public class AnypointMQProcessorComponent extends AbstractProcessorComponent {
   }
 
   @Override
-  public Optional<TraceComponent> getSourceTraceComponent(EnrichedServerNotification notification,
+  public Optional<TraceComponent> getSourceStartTraceComponent(EnrichedServerNotification notification,
       TraceContextHandler traceContextHandler) {
     TypedValue<AnypointMQMessageAttributes> attributesTypedValue = notification.getEvent().getMessage()
         .getAttributes();

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/TraceComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/TraceComponent.java
@@ -1,6 +1,7 @@
 package com.avioconsulting.mule.opentelemetry.internal.processor;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import java.util.Map;
 
@@ -13,6 +14,7 @@ public class TraceComponent {
   private Context context;
   private SpanKind spanKind = SpanKind.INTERNAL;
   private String errorMessage;
+  private StatusCode statusCode = StatusCode.UNSET;
 
   private TraceComponent(Builder builder) {
     tags = builder.tags;
@@ -23,6 +25,7 @@ public class TraceComponent {
     context = builder.context;
     spanKind = builder.spanKind;
     errorMessage = builder.errorMessage;
+    statusCode = builder.statusCode;
   }
 
   public static Builder newBuilder(String name) {
@@ -69,10 +72,16 @@ public class TraceComponent {
         .withTags(this.getTags())
         .withSpanName(this.getSpanName())
         .withLocation(this.getLocation())
-        .withSpanKind(this.getSpanKind());
+        .withSpanKind(this.getSpanKind())
+        .withStatsCode(this.getStatusCode());
+  }
+
+  public StatusCode getStatusCode() {
+    return statusCode;
   }
 
   public static final class Builder {
+    public StatusCode statusCode;
     private Map<String, String> tags;
     private final String name;
     private String transactionId;
@@ -118,6 +127,11 @@ public class TraceComponent {
 
     public Builder withErrorMessage(String val) {
       errorMessage = val;
+      return this;
+    }
+
+    public Builder withStatsCode(StatusCode statusCode) {
+      this.statusCode = statusCode;
       return this;
     }
 

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
@@ -21,6 +21,7 @@ import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
@@ -34,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "org.apache.derby:derby" })
 public abstract class AbstractMuleArtifactTraceTest extends MuleArtifactFunctionalTestCase {
 
+  public static final String CORRELATION_ID = UUID.randomUUID().toString();
   @Rule
   public DynamicPort serverPort = new DynamicPort("http.port");
 

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponentSourceTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponentSourceTest.java
@@ -1,0 +1,102 @@
+package com.avioconsulting.mule.opentelemetry.internal.processor;
+
+import com.avioconsulting.mule.opentelemetry.internal.connection.TraceContextHandler;
+import io.opentelemetry.api.trace.StatusCode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mule.extension.http.api.HttpRequestAttributes;
+import org.mule.runtime.api.component.Component;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.event.Event;
+import org.mule.runtime.api.event.EventContext;
+import org.mule.runtime.api.message.Message;
+import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.api.notification.MessageProcessorNotification;
+import org.mule.runtime.api.util.MultiMap;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class HttpProcessorComponentSourceTest extends AbstractProcessorComponentTest {
+
+  @Parameterized.Parameter(value = 0)
+  public String httpStatus;
+
+  @Parameterized.Parameter(value = 1)
+  public StatusCode spanStatusCode;
+
+  /**
+   * HTTP Status codes and OpenTelemetry expected Span Status Codes for Server
+   * spans.
+   * 
+   * @return
+   */
+  @Parameters()
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        { "99", StatusCode.ERROR },
+        { "100", StatusCode.UNSET },
+        { "200", StatusCode.UNSET },
+        { "300", StatusCode.UNSET },
+        { "400", StatusCode.UNSET },
+        { "500", StatusCode.ERROR }
+    });
+  }
+
+  @Test
+  public void onSuccessWithResponseAttributes_getSourceEndTraceComponent() {
+    Event event = mock(Event.class);
+    when(event.getCorrelationId()).thenReturn("testCorrelationId");
+    EventContext eventContext = mock(EventContext.class);
+    ComponentLocation originatingLocation = getComponentLocation("http", "listener");
+    when(eventContext.getOriginatingLocation()).thenReturn(originatingLocation);
+    when(event.getContext()).thenReturn(eventContext);
+
+    HttpRequestAttributes requestAttributes = mock(HttpRequestAttributes.class);
+    when(requestAttributes.getMethod()).thenReturn("GET");
+    when(requestAttributes.getScheme()).thenReturn("HTTP");
+    when(requestAttributes.getListenerPath()).thenReturn("/test");
+    when(requestAttributes.getRequestPath()).thenReturn("/test");
+    when(requestAttributes.getVersion()).thenReturn("HTTP/1.1");
+
+    when(event.getVariables()).thenReturn(Collections.singletonMap("httpStatus", TypedValue.of(httpStatus)));
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put("host", "localhost");
+    headers.put("user-agent", "test-unit");
+    when(requestAttributes.getHeaders()).thenReturn(new MultiMap<>(headers));
+
+    Message message = getMessage(requestAttributes);
+    when(event.getMessage()).thenReturn(message);
+
+    ComponentLocation componentLocation = getComponentLocation();
+
+    Map<String, String> config = new HashMap<>();
+    config.put("name", "test-flow");
+    Component component = getComponent(getComponentLocation(), config, "mule", "flow");
+
+    Exception exception = mock(Exception.class);
+    MessageProcessorNotification notification = MessageProcessorNotification.createFrom(event, componentLocation,
+        component, exception, MessageProcessorNotification.MESSAGE_PROCESSOR_POST_INVOKE);
+
+    HttpProcessorComponent httpProcessorComponent = new HttpProcessorComponent();
+    TraceContextHandler traceContextHandler = mock(TraceContextHandler.class);
+    Optional<TraceComponent> sourceTraceComponent = httpProcessorComponent.getSourceEndTraceComponent(
+        notification,
+        traceContextHandler);
+
+    assertThat(sourceTraceComponent)
+        .isNotEmpty()
+        .get()
+        .extracting("name", "spanName", "statusCode").containsExactly("test-flow", null, spanStatusCode);
+    assertThat(sourceTraceComponent.get().getTags())
+        .containsEntry("http.status_code", httpStatus);
+  }
+
+}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponentTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponentTest.java
@@ -74,7 +74,7 @@ public class HttpProcessorComponentTest extends AbstractProcessorComponentTest {
 
     assertThat(endTraceComponent).isNotNull()
         .extracting("errorMessage").isEqualTo("Something failed");
-    assertThat(endTraceComponent.getTags()).isNull();
+    assertThat(endTraceComponent.getTags()).isEmpty();
 
   }
 
@@ -98,7 +98,7 @@ public class HttpProcessorComponentTest extends AbstractProcessorComponentTest {
 
     assertThat(endTraceComponent).isNotNull()
         .extracting("errorMessage").isEqualTo("Something failed");
-    assertThat(endTraceComponent.getTags()).isNull();
+    assertThat(endTraceComponent.getTags()).isEmpty();
   }
 
   @Test
@@ -146,7 +146,7 @@ public class HttpProcessorComponentTest extends AbstractProcessorComponentTest {
   }
 
   @Test
-  public void onSuccessWithResponseAttributes_getSourceTraceComponent() {
+  public void onSuccessWithResponseAttributes_getSourceStartTraceComponent() {
     Event event = mock(Event.class);
     when(event.getCorrelationId()).thenReturn("testCorrelationId");
     EventContext eventContext = mock(EventContext.class);
@@ -181,7 +181,8 @@ public class HttpProcessorComponentTest extends AbstractProcessorComponentTest {
 
     HttpProcessorComponent httpProcessorComponent = new HttpProcessorComponent();
     TraceContextHandler traceContextHandler = mock(TraceContextHandler.class);
-    Optional<TraceComponent> sourceTraceComponent = httpProcessorComponent.getSourceTraceComponent(notification,
+    Optional<TraceComponent> sourceTraceComponent = httpProcessorComponent.getSourceStartTraceComponent(
+        notification,
         traceContextHandler);
 
     assertThat(sourceTraceComponent)

--- a/src/test/resources/mule-opentelemetry-http.xml
+++ b/src/test/resources/mule-opentelemetry-http.xml
@@ -11,12 +11,40 @@ http://www.mulesoft.org/schema/mule/opentelemetry http://www.mulesoft.org/schema
 	<http:request-config name="INVALID_HTTP_BasePath_Request_configuration" doc:name="HTTP Request configuration" doc:id="c18eed36-eb42-4c29-abc9-9e7a2c6049e1" basePath="/api" >
 		<http:request-connection host="0.0.0.0" port="9085" />
 	</http:request-config>
+	<flow name="http-wildcard-listener" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+		<http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/test-wildcard/*"/>
+		<logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
+		<set-payload value="Received in App2" doc:name="Set Payload" doc:id="6bb91307-b173-4256-8c64-491dad475af7" />
+		<set-variable variableName="httpStatus" value="#[200]"/>
+		<logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
+	</flow>
 	<flow name="mule-opentelemetry-app-2Flow" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
 		<http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/test"/>
 		<logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
 		<set-payload value="Received in App2" doc:name="Set Payload" doc:id="6bb91307-b173-4256-8c64-491dad475af7" />
+		<set-variable variableName="httpStatus" value="#[200]"/>
 		<logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
 	</flow>
+	<flow name="http-test-without-status-variable" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+		<http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/test/no-status"/>
+		<logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
+		<set-payload value="Received in App2" doc:name="Set Payload" doc:id="6bb91307-b173-4256-8c64-491dad475af7" />
+		<!--<set-variable variableName="httpStatus" value="#[200]"/>-->
+		<logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
+	</flow>
+	<flow name="http-test-errorResponse-status-variable" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+		<http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/test/error-status"/>
+		<logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
+		<set-payload value="Received in App2" doc:name="Set Payload" doc:id="6bb91307-b173-4256-8c64-491dad475af7" />
+		<raise-error doc:name="Raise error" doc:id="049f12f1-24cd-4337-868c-96c140dde0b8" type="ANY"/>
+		<logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
+		<error-handler >
+			<on-error-propagate enableNotifications="true" logException="true" doc:name="On Error Propagate" doc:id="e594b839-276b-4a11-b6ce-c54920f408ad" >
+				<set-variable value="#[500]" doc:name="Set Variable" doc:id="4ce4adfa-65e5-4936-ae99-bd74638ece3c" variableName="httpStatus"/>
+			</on-error-propagate>
+		</error-handler>
+	</flow>
+
 	<flow name="mule-opentelemetry-app-2-interceptor-test" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
 		<logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
 		<set-payload value="Received in App2" doc:name="Set Payload" doc:id="6bb91307-b173-4256-8c64-491dad475af7" />


### PR DESCRIPTION
1. Capture HTTP Response status code and set the span status
   accordingly.
2. Exceptions should not set the span status to Error but just record it
   as an event.
3. Allow components to prepare end trace details in case of source
   notification.