### PR TITLE
Add request compression param for OTLP exporter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,7 +49,7 @@ Following example shows an OpenTelemetry Config with OTLP Exporter configured -
 ----
 <opentelemetry:config name="OpenTelemetry_Config" doc:name="OpenTelemetry Config" doc:id="91477cb5-36f7-48ad-90b7-c339af87b408" serviceName="api-app-1">
     <opentelemetry:exporter >
-        <opentelemetry:otlp-exporter collectorEndpoint="http://localhost:55681/v1" protocol="HTTP_PROTOBUF" >
+        <opentelemetry:otlp-exporter collectorEndpoint="http://localhost:55681/v1" protocol="HTTP_PROTOBUF" requestCompression="GZIP">
             <opentelemetry:headers >
                 <opentelemetry:header key="testHeader" value="testHeaderValue" />
             </opentelemetry:headers>

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/Attribute.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/Attribute.java
@@ -4,4 +4,12 @@ import org.mule.runtime.extension.api.annotation.Alias;
 
 @Alias("attribute")
 public class Attribute extends KeyValuePair {
+
+  public Attribute() {
+    super();
+  }
+
+  public Attribute(String key, String value) {
+    super(key, value);
+  }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/Header.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/Header.java
@@ -4,4 +4,12 @@ import org.mule.runtime.extension.api.annotation.Alias;
 
 @Alias("header")
 public class Header extends KeyValuePair {
+
+  public Header() {
+    super();
+  }
+
+  public Header(String key, String value) {
+    super(key, value);
+  }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/KeyValuePair.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/KeyValuePair.java
@@ -22,6 +22,14 @@ public abstract class KeyValuePair {
     return value;
   }
 
+  public KeyValuePair() {
+  }
+
+  public KeyValuePair(String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o)

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporter.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporter.java
@@ -15,6 +15,12 @@ import java.util.stream.Collectors;
 
 public class OtlpExporter extends AbstractExporter {
 
+  public static final String OTLP = "otlp";
+  public static final String OTEL_EXPORTER_OTLP_PROTOCOL = "otel.exporter.otlp.protocol";
+  public static final String OTEL_EXPORTER_OTLP_ENDPOINT = "otel.exporter.otlp.endpoint";
+  public static final String OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "otel.exporter.otlp.traces.endpoint";
+  public static final String OTEL_EXPORTER_OTLP_COMPRESSION = "otel.exporter.otlp.compression";
+  public static final String OTEL_EXPORTER_OTLP_HEADERS = "otel.exporter.otlp.headers";
   @Parameter
   @Optional
   @Summary(value = "The OTLP traces, metrics, and logs endpoint to connect to. Must be a URL with a scheme of either http or https based on the use of TLS."
@@ -29,6 +35,12 @@ public class OtlpExporter extends AbstractExporter {
   private Protocol protocol;
 
   @Parameter
+  @Optional(defaultValue = "NONE")
+  @DisplayName(value = "Request Compression")
+  @Summary("The compression type to use on OTLP trace, metric, and log requests.")
+  private OtlpRequestCompression requestCompression;
+
+  @Parameter
   @DisplayName("Headers")
   @Optional
   @NullSafe
@@ -39,20 +51,54 @@ public class OtlpExporter extends AbstractExporter {
     return headers;
   }
 
+  public OtlpRequestCompression getRequestCompression() {
+    return requestCompression;
+  }
+
   public String getCollectorEndpoint() {
     return collectorEndpoint;
   }
 
+  /**
+   * Default constructor used by Mule SDK to instantiate this class.
+   */
+  public OtlpExporter() {
+
+  }
+
+  /**
+   * Constructor used for testing purpose.
+   * 
+   * @param collectorEndpoint
+   *            where span are delivered.
+   * @param protocol
+   *            {@link Protocol} used by the collector
+   * @param requestCompression
+   *            {@link OtlpRequestCompression} to use for request compression
+   * @param headers
+   *            {@link List} of {@link Header} elements to send to collector
+   */
+  OtlpExporter(String collectorEndpoint, Protocol protocol, OtlpRequestCompression requestCompression,
+      List<Header> headers) {
+    this.collectorEndpoint = collectorEndpoint;
+    this.protocol = protocol;
+    this.requestCompression = requestCompression;
+    this.headers = headers;
+  }
+
   public Map<String, String> getExporterProperties() {
     Map<String, String> config = super.getExporterProperties();
-    config.put(OTEL_TRACES_EXPORTER_KEY, "otlp");
-    config.put("otel.exporter.otlp.protocol", protocol.getValue());
-    config.put("otel.exporter.otlp.endpoint", getCollectorEndpoint());
+    config.put(OTEL_TRACES_EXPORTER_KEY, OTLP);
+    config.put(OTEL_EXPORTER_OTLP_PROTOCOL, protocol.getValue());
+    config.put(OTEL_EXPORTER_OTLP_ENDPOINT, getCollectorEndpoint());
     // Set Traces endpoint when using HTTP/Protobuf only
     if (protocol.equals(Protocol.HTTP_PROTOBUF)) {
-      config.put("otel.exporter.otlp.traces.endpoint", getSignalEndpoint("traces"));
+      config.put(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, getSignalEndpoint("traces"));
     }
-    config.put("otel.exporter.otlp.headers", KeyValuePair.commaSeparatedList(getHeaders()));
+    if (!OtlpRequestCompression.NONE.equals(requestCompression)) {
+      config.put(OTEL_EXPORTER_OTLP_COMPRESSION, requestCompression.getValue());
+    }
+    config.put(OTEL_EXPORTER_OTLP_HEADERS, KeyValuePair.commaSeparatedList(getHeaders()));
     return Collections.unmodifiableMap(config);
   }
 
@@ -100,6 +146,33 @@ public class OtlpExporter extends AbstractExporter {
 
     Protocol fromValue(String value) {
       return protocols.get(value);
+    }
+  }
+
+  /**
+   * The compression type to use on OTLP trace, metric, and log requests.
+   */
+  public enum OtlpRequestCompression {
+    NONE("none"), GZIP("gzip");
+
+    private final String value;
+    private static Map<String, OtlpRequestCompression> compressions;
+
+    OtlpRequestCompression(String value) {
+      this.value = value;
+    }
+
+    static {
+      compressions = Arrays.stream(OtlpRequestCompression.values())
+          .collect(Collectors.toMap(OtlpRequestCompression::getValue, Function.identity()));
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    OtlpRequestCompression fromValue(String value) {
+      return compressions.get(value);
     }
   }
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporterTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporterTest.java
@@ -1,0 +1,37 @@
+package com.avioconsulting.mule.opentelemetry.api.config.exporter;
+
+import com.avioconsulting.mule.opentelemetry.api.config.Header;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static com.avioconsulting.mule.opentelemetry.api.config.exporter.OtlpExporter.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OtlpExporterTest {
+
+  @Test
+  public void verifyConfigProperties() {
+    java.util.List<Header> headers = new java.util.ArrayList<>();
+    headers.add(new Header("test", "value"));
+    headers.add(new Header("test2", "value2"));
+    OtlpExporter otlpExporter = new OtlpExporter("http://localhost", OtlpExporter.Protocol.HTTP_PROTOBUF,
+        OtlpExporter.OtlpRequestCompression.GZIP, headers);
+    assertThat(otlpExporter.getExporterProperties())
+        .containsEntry(OTEL_TRACES_EXPORTER_KEY, OTLP)
+        .containsEntry(OTEL_EXPORTER_OTLP_COMPRESSION, OtlpExporter.OtlpRequestCompression.GZIP.getValue())
+        .containsEntry(OTEL_EXPORTER_OTLP_PROTOCOL, Protocol.HTTP_PROTOBUF.getValue())
+        .containsEntry(OTEL_EXPORTER_OTLP_HEADERS, "test=value,test2=value2")
+        .containsEntry(OTEL_EXPORTER_OTLP_ENDPOINT, "http://localhost")
+        .containsEntry(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, "http://localhost/traces");
+  }
+
+  @Test
+  public void verifyNoCompressionSet() {
+    OtlpExporter otlpExporter = new OtlpExporter("http://localhost", OtlpExporter.Protocol.HTTP_PROTOBUF,
+        OtlpExporter.OtlpRequestCompression.NONE, Collections.emptyList());
+    assertThat(otlpExporter.getExporterProperties())
+        .doesNotContainKey(OTEL_EXPORTER_OTLP_COMPRESSION);
+  }
+
+}

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -6,7 +6,13 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="io.opentelemetry" level="ALL">
+        <Logger name="io.opentelemetry.exporter" level="DEBUG">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Logger name="com.avioconsulting.mule.opentelemetry" level="DEBUG">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Logger name="org.mule.runtime.core.internal.context.notification" level="DEBUG">
             <AppenderRef ref="Console"/>
         </Logger>
         <Root level="INFO">


### PR DESCRIPTION
Fixes #45 

New Request Compression parameter on the OpenTelemetry Exporter config - 

![image](https://user-images.githubusercontent.com/877286/189428699-356bd6e0-8815-4f80-a134-113f50278052.png)
