### PR TITLE
Configuration for tracing controls

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -167,8 +167,21 @@ The required Zipkin exporter dependencies must be configured as an https://docs.
 </plugin>
 ----
 
+=== Span Processors
+For non-logging exporters, Tracing SDK uses https://opentelemetry.io/docs/reference/specification/trace/sdk/#batching-processor[Batch Span Processor]. Global Configuration allows to customize Batch span processor settings -
 
-
+[source,xml]
+.OpenTelemetry config with Batch span processor default values
+----
+<opentelemetry:config name="OpenTelemetry_Config"
+    serviceName="otel-comparison-test"
+    maxQueueSize="2048"
+    maxBatchExportSize="512"
+    batchExportDelayInterval="5000"
+    exportTimeout="30000">
+.... other config ....
+</opentelemetry:config>
+----
 
 == Trace Spans
 Trace spans are created for only following mule components -
@@ -178,7 +191,36 @@ Trace spans are created for only following mule components -
 - Database Connector
 - Anypoint MQ Connector
 
-NOTE: This can be changed to create spans for every mule processors by setting `spanAllProcessors = "false"` (can be overridden by setting system property `mule.otel.span.processors.enable` to `true|false`).
+=== Trace Levels
+
+Module can create spans for every mule processors by setting `spanAllProcessors = "true"`. This can be overridden by setting a system property `mule.otel.span.processors.enable` to `true|false`.
+
+When the span generation for all processors is enabled, `opentelemetry:ignore-mule-components` allows to set a list of processors to exclude from span generation.
+
+[source,xml]
+.OpenTelemetry Config with trace level configuration
+----
+<opentelemetry:config name="OpenTelemetry_Generic" doc:name="OpenTelemetry Config" serviceName="app1"  spanAllProcessors="true">
+    <opentelemetry:exporter >
+        <opentelemetry:generic-exporter >
+            <opentelemetry:config-properties >
+                <opentelemetry:config-property key="otel.traces.exporter" value="zipkin" />
+                <opentelemetry:config-property key="otel.exporter.zipkin.endpoint" value="http://localhost:9411/api/v2/spans" />
+            </opentelemetry:config-properties>
+        </opentelemetry:generic-exporter>
+    </opentelemetry:exporter>
+    <opentelemetry:ignore-mule-components >
+        <opentelemetry:mule-component namespace="MULE" name="LOGGER" />
+        <opentelemetry:mule-component namespace="os" name="*" />
+    </opentelemetry:ignore-mule-components>
+</opentelemetry:config>
+----
+
+To disable span generation for all processors in a specific namespace, set the `name` attribute to `*`
+-
+----
+<opentelemetry:mule-component namespace="os" name="*" />
+----
 
 == Context Propagation
 

--- a/README.adoc
+++ b/README.adoc
@@ -295,6 +295,23 @@ When using Anypoint MQ, the `publish` operation can add `vars.OTEL_TRACE_CONTEXT
 
 == Limitations
 - Automatic header/attribute injections for outbound requests is not supported
+- When using in on-premise mode, all applications deployed to the same runtime will share the same instance of OpenTelemetry configuration. It is unpredictable that which application's configuration wins. Ideally, the configuration should be same across the applications.
+
+== Turn Off Tracing
+
+Once you have configured the module in your application, there may be a need to remove or temporarily turn it off.
+
+*To permanently remove* the tracing -
+
+- Remove the module dependency from pom.xml
+- Remove the global configuration element and xml declaration references
+- Remove any changes made to other Connector configurations for context propagation.
+
+*To temporarily disable* the tracing without any code changes -
+
+- Set `turnOffTracing="true"` on global config. You may use a property placeholder for the value.
+- Alternately, you can set the `mule.otel.tracing.disabled` system property to `true`.
+- To re-enable the tracing, just reset the property to `false` (default value).
 
 == Testing
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.connectors</groupId>
+            <artifactId>mule-objectstore-connector</artifactId>
+            <version>1.2.1</version>
+            <classifier>mule-plugin</classifier>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
             <version>10.14.2.0</version>

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/MuleComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/MuleComponent.java
@@ -1,0 +1,66 @@
+package com.avioconsulting.mule.opentelemetry.api.config;
+
+import org.mule.runtime.extension.api.annotation.Alias;
+import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.extension.api.annotation.param.display.Example;
+import org.mule.runtime.extension.api.annotation.param.display.Summary;
+
+import java.util.Objects;
+
+public class MuleComponent {
+
+  @Parameter
+  @Summary("Mule Component Namespace")
+  @Example("mule")
+  private String namespace;
+
+  @Parameter
+  @Summary("Mule Component Name")
+  @Example("logger")
+  private String name;
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public void setNamespace(String namespace) {
+    this.namespace = namespace;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public MuleComponent() {
+
+  }
+
+  public MuleComponent(String namespace, String name) {
+    this.namespace = namespace;
+    this.name = name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    MuleComponent that = (MuleComponent) o;
+    return getNamespace().equals(that.getNamespace()) && getName().equals(that.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getNamespace(), getName());
+  }
+
+  @Override
+  public String toString() {
+    return getNamespace().concat(":").concat(getName());
+  }
+}

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/OtelConfigMapProvider.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/OtelConfigMapProvider.java
@@ -11,10 +11,10 @@ public interface OtelConfigMapProvider {
 
   /**
    * The implementation of {@link #getConfigMap()} must return a
-   * {@link Map<String, String>}
+   * {@link Map}
    * with OpenTelemetry semantic attribute keys and appropriate values.
    * 
-   * @return {@link Map<String, String>}
+   * @return {@link Map}
    */
   Map<String, String> getConfigMap();
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/TraceLevelConfiguration.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/TraceLevelConfiguration.java
@@ -1,23 +1,44 @@
 package com.avioconsulting.mule.opentelemetry.api.config;
 
-import org.mule.runtime.api.meta.ExpressionSupport;
-import org.mule.runtime.extension.api.annotation.Expression;
+import org.mule.runtime.extension.api.annotation.param.NullSafe;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
+import org.mule.runtime.extension.api.annotation.param.display.Placement;
 import org.mule.runtime.extension.api.annotation.param.display.Summary;
+
+import java.util.List;
 
 public class TraceLevelConfiguration {
 
   @Parameter
   @Optional(defaultValue = "false")
+  @Placement(order = 1)
   @DisplayName(value = "Span All Processors")
   @Summary("By default, Spans are created for known components only. Setting this flag to true will create trace spans for every processor in a flow.")
-  @Expression(ExpressionSupport.NOT_SUPPORTED)
   private boolean spanAllProcessors = false;
+
+  @Parameter
+  @NullSafe
+  @Optional
+  @Placement(order = 1)
+  @DisplayName(value = "Disable Spans for")
+  @Summary("When generating spans for all processors, this list defines the processors that should be skipped from tracing. No spans will be generated for these components.")
+  private List<MuleComponent> ignoreMuleComponents;
+
+  public TraceLevelConfiguration() {
+  }
+
+  public TraceLevelConfiguration(boolean spanAllProcessors, List<MuleComponent> ignoreMuleComponents) {
+    this.spanAllProcessors = spanAllProcessors;
+    this.ignoreMuleComponents = ignoreMuleComponents;
+  }
 
   public boolean isSpanAllProcessors() {
     return spanAllProcessors;
   }
 
+  public List<MuleComponent> getIgnoreMuleComponents() {
+    return ignoreMuleComponents;
+  }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/config/OpenTelemetryExtensionConfiguration.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/config/OpenTelemetryExtensionConfiguration.java
@@ -96,7 +96,7 @@ public class OpenTelemetryExtensionConfiguration implements Startable {
         () -> OpenTelemetryConnection
             .getInstance(new OpenTelemetryConfigWrapper(getResource(),
                 getExporterConfiguration().getExporter(), getSpanProcessorConfiguration())),
-        getTraceLevelConfiguration().isSpanAllProcessors());
+        getTraceLevelConfiguration());
     notificationListenerRegistry.registerListener(
         new MuleMessageProcessorNotificationListener(muleNotificationProcessor));
     notificationListenerRegistry.registerListener(

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/FirstProcessorInterceptorFactory.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/FirstProcessorInterceptorFactory.java
@@ -1,9 +1,13 @@
 package com.avioconsulting.mule.opentelemetry.internal.interceptor;
 
+import com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryExtensionConfiguration;
+import com.avioconsulting.mule.opentelemetry.internal.processor.MuleNotificationProcessor;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.interception.ProcessorInterceptor;
 import org.mule.runtime.api.interception.ProcessorInterceptorFactory;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
 
 /**
  * ProcessorInterceptorFactory can intercept processors. This is injected
@@ -21,14 +25,30 @@ public class FirstProcessorInterceptorFactory implements ProcessorInterceptorFac
   private final boolean interceptorEnabled = Boolean
       .parseBoolean(System.getProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME, "true"));
 
+  /**
+   * {@link MuleNotificationProcessor} instance for getting opentelemetry
+   * connection supplier by processor.
+   */
+  private final MuleNotificationProcessor muleNotificationProcessor;
+
+  @Inject
+  public FirstProcessorInterceptorFactory(MuleNotificationProcessor muleNotificationProcessor) {
+    this.muleNotificationProcessor = muleNotificationProcessor;
+  }
+
   @Override
   public ProcessorInterceptor get() {
-    return new ProcessorTracingInterceptor();
+    return new ProcessorTracingInterceptor(muleNotificationProcessor);
   }
 
   /**
    * This intercepts the first processor of root container which can be a flow or
    * sub-flow.
+   *
+   * This will not intercept if "mule.otel.interceptor.processor.enable" is set to
+   * `true` Or {@link MuleNotificationProcessor} does not have a valid connection
+   * due to disabled tracing. See
+   * {@link OpenTelemetryExtensionConfiguration#start()}.
    *
    * @param location
    *            {@link ComponentLocation}
@@ -36,6 +56,7 @@ public class FirstProcessorInterceptorFactory implements ProcessorInterceptorFac
    */
   @Override
   public boolean intercept(ComponentLocation location) {
-    return interceptorEnabled && location.getLocation().endsWith("/0");
+    return muleNotificationProcessor.hasConnection() &&
+        interceptorEnabled && location.getLocation().endsWith("/0");
   }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessor.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessor.java
@@ -46,6 +46,14 @@ public class MuleNotificationProcessor {
 
   }
 
+  public boolean hasConnection() {
+    return connectionSupplier != null;
+  }
+
+  public Supplier<OpenTelemetryConnection> getConnectionSupplier() {
+    return connectionSupplier;
+  }
+
   public void init(Supplier<OpenTelemetryConnection> connectionSupplier, boolean spanAllProcessors) {
     init(connectionSupplier, new TraceLevelConfiguration(spanAllProcessors, Collections.emptyList()));
   }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
@@ -54,7 +54,9 @@ public abstract class AbstractMuleArtifactTraceTest extends MuleArtifactFunction
 
   @After
   public void clearSpansQueue() {
-    Awaitility.await().untilAsserted(() -> assertThat(DelegatedLoggingSpanExporter.spanQueue).isNotEmpty());
+    Awaitility.await().untilAsserted(() -> assertThat(DelegatedLoggingSpanExporter.spanQueue).as(
+        "Cleaning span queue with @Before. If It is expected to be empty, override clearSpansQueue from abstract test.")
+        .isNotEmpty());
     DelegatedLoggingSpanExporter.spanQueue.clear();
   }
 

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryDisableTracingTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryDisableTracingTest.java
@@ -1,0 +1,45 @@
+package com.avioconsulting.mule.opentelemetry;
+
+import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.DelegatedLoggingSpanExporterProvider;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class MuleOpenTelemetryDisableTracingTest extends AbstractMuleArtifactTraceTest {
+
+  @Override
+  protected void doSetUpBeforeMuleContextCreation() throws Exception {
+    super.doSetUpBeforeMuleContextCreation();
+    System.setProperty("mule.otel.tracing.disabled", "true");
+  }
+
+  @Override
+  protected void doTearDownAfterMuleContextDispose() throws Exception {
+    super.doTearDownAfterMuleContextDispose();
+    System.clearProperty("mule.otel.tracing.disabled");
+  }
+
+  @Override
+  protected String getConfigFile() {
+    return "mule-opentelemetry-processor-enabled.xml";
+  }
+
+  @After
+  @Override
+  public void clearSpansQueue() {
+
+  }
+
+  @Test
+  public void tracingDisabledBySystemProperty() throws Exception {
+    sendRequest(UUID.randomUUID().toString(), "test", 200);
+    await().untilAsserted(
+        () -> assertThat(DelegatedLoggingSpanExporterProvider.DelegatedLoggingSpanExporter.spanQueue)
+            .as("Spans for listener and processors")
+            .hasSize(0));
+  }
+}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorEnabledTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorEnabledTest.java
@@ -1,6 +1,7 @@
 package com.avioconsulting.mule.opentelemetry;
 
 import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.DelegatedLoggingSpanExporterProvider;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.UUID;
@@ -9,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.awaitility.Awaitility.await;
 
-public class MuleOpenTelemetryProcessorEnabled extends AbstractMuleArtifactTraceTest {
+public class MuleOpenTelemetryProcessorEnabledTest extends AbstractMuleArtifactTraceTest {
 
   @Override
   protected String getConfigFile() {
@@ -28,5 +29,24 @@ public class MuleOpenTelemetryProcessorEnabled extends AbstractMuleArtifactTrace
                 tuple("set-payload:Set Payload", "INTERNAL"),
                 tuple("logger:Logger", "INTERNAL"),
                 tuple("/test", "SERVER")));
+  }
+
+  /**
+   * Disabled Mule functional test is unable to recognize `name` parameter
+   * keeps throwing `Parameter 'name' is required but was not found`
+   * 
+   * @throws Exception
+   */
+  @Test
+  @Ignore
+  public void testProcessorSkipping() throws Exception {
+    sendRequest(UUID.randomUUID().toString(), "otel-processor-flow", 200);
+    await().untilAsserted(
+        () -> assertThat(DelegatedLoggingSpanExporterProvider.DelegatedLoggingSpanExporter.spanQueue)
+            .as("Spans for listener and processors")
+            .hasSize(2)
+            .extracting("spanName", "spanKind")
+            .containsOnly(tuple("set-payload:Set Payload", "INTERNAL"),
+                tuple("/otel-processor-flow", "SERVER")));
   }
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorPropertyOverrideTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorPropertyOverrideTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.awaitility.Awaitility.await;
 
-public class MuleOpenTelemetryProcessorPropertyOverride extends AbstractMuleArtifactTraceTest {
+public class MuleOpenTelemetryProcessorPropertyOverrideTest extends AbstractMuleArtifactTraceTest {
 
   @Override
   protected void doSetUpBeforeMuleContextCreation() throws Exception {

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/FirstProcessorInterceptorFactoryTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/FirstProcessorInterceptorFactoryTest.java
@@ -1,46 +1,71 @@
 package com.avioconsulting.mule.opentelemetry.internal.interceptor;
 
+import com.avioconsulting.mule.opentelemetry.internal.processor.MuleNotificationProcessor;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mule.runtime.api.component.location.ComponentLocation;
 
 import static com.avioconsulting.mule.opentelemetry.internal.interceptor.FirstProcessorInterceptorFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class FirstProcessorInterceptorFactoryTest {
+
+  @Mock
+  MuleNotificationProcessor muleNotificationProcessor;
+
+  @Before
+  public void setMocks() {
+    when(muleNotificationProcessor.hasConnection()).thenReturn(true);
+  }
 
   @Test
   public void get() {
-    assertThat(new FirstProcessorInterceptorFactory().get())
+    assertThat(new FirstProcessorInterceptorFactory(muleNotificationProcessor).get())
         .isInstanceOf(ProcessorTracingInterceptor.class);
   }
 
   @Test
   public void notInterceptionNonZeroProcessors() {
     ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    Mockito.when(location.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
-    assertThat(new FirstProcessorInterceptorFactory().intercept(location))
+    when(location.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
+    assertThat(new FirstProcessorInterceptorFactory(muleNotificationProcessor).intercept(location))
         .isFalse();
   }
 
   @Test
   public void interceptionDefaultEnabled() {
     ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    Mockito.when(location.getLocation()).thenReturn("MyFlow/processors/0");
-    assertThat(new FirstProcessorInterceptorFactory().intercept(location))
+    when(location.getLocation()).thenReturn("MyFlow/processors/0");
+    assertThat(new FirstProcessorInterceptorFactory(muleNotificationProcessor).intercept(location))
         .isTrue();
+  }
+
+  @Test
+  public void interceptionDisabledDueToNotificationListener() {
+    reset(muleNotificationProcessor);
+    when(muleNotificationProcessor.hasConnection()).thenReturn(false);
+    ComponentLocation location = Mockito.mock(ComponentLocation.class);
+    assertThat(new FirstProcessorInterceptorFactory(muleNotificationProcessor).intercept(location))
+        .isFalse();
   }
 
   @Test
   public void interceptionDisabledBySystemProperty() {
     ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    Mockito.when(location.getLocation()).thenReturn("MyFlow/processors/0");
-    assertThat(new FirstProcessorInterceptorFactory().intercept(location))
+    when(location.getLocation()).thenReturn("MyFlow/processors/0");
+    assertThat(new FirstProcessorInterceptorFactory(muleNotificationProcessor).intercept(location))
         .as("Interception before system property")
         .isTrue();
     System.setProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME, "false");
 
-    assertThat(new FirstProcessorInterceptorFactory().intercept(location))
+    assertThat(new FirstProcessorInterceptorFactory(muleNotificationProcessor).intercept(location))
         .as("Interception after system property")
         .isFalse();
     System.clearProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME);

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptorTest.java
@@ -1,6 +1,7 @@
 package com.avioconsulting.mule.opentelemetry.internal.interceptor;
 
 import com.avioconsulting.mule.opentelemetry.internal.connection.OpenTelemetryConnection;
+import com.avioconsulting.mule.opentelemetry.internal.processor.MuleNotificationProcessor;
 import com.avioconsulting.mule.opentelemetry.internal.store.TransactionStore;
 import org.junit.Test;
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -24,8 +25,9 @@ public class ProcessorTracingInterceptorTest {
     Map<String, String> traceparentMap = Collections.singletonMap("traceparent", "some-value");
     when(connection.getTraceContext("random-id"))
         .thenReturn(traceparentMap);
-    ProcessorTracingInterceptor interceptor = new ProcessorTracingInterceptor();
-    interceptor.setConnectionSupplier(() -> Optional.of(connection));
+    MuleNotificationProcessor muleNotificationProcessor = mock(MuleNotificationProcessor.class);
+    when(muleNotificationProcessor.getConnectionSupplier()).thenReturn(() -> connection);
+    ProcessorTracingInterceptor interceptor = new ProcessorTracingInterceptor(muleNotificationProcessor);
     ComponentLocation location = mock(ComponentLocation.class);
     InterceptionEvent interceptionEvent = mock(InterceptionEvent.class);
     interceptor.before(location, Collections.emptyMap(), interceptionEvent);

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessorTest.java
@@ -1,5 +1,7 @@
 package com.avioconsulting.mule.opentelemetry.internal.processor;
 
+import com.avioconsulting.mule.opentelemetry.api.config.MuleComponent;
+import com.avioconsulting.mule.opentelemetry.api.config.TraceLevelConfiguration;
 import com.avioconsulting.mule.opentelemetry.internal.connection.OpenTelemetryConnection;
 import org.junit.Test;
 import org.mule.runtime.api.component.Component;
@@ -8,7 +10,9 @@ import org.mule.runtime.api.event.Event;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.notification.MessageProcessorNotification;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 
@@ -36,6 +40,57 @@ public class MuleNotificationProcessorTest extends AbstractProcessorComponentTes
   }
 
   @Test
+  public void handleProcessorStartEvent_withSkippedNamedProcessorSpans() {
+
+    Event event = mock(Event.class);
+    when(event.getCorrelationId()).thenReturn("testCorrelationId");
+    Message message = getMessage(null);
+    when(event.getMessage()).thenReturn(message);
+    ComponentLocation componentLocation = getComponentLocation("mule", "logger");
+    Component component = getComponent(componentLocation, Collections.emptyMap(), "mule", "logger");
+    Exception exception = mock(Exception.class);
+    MessageProcessorNotification notification = MessageProcessorNotification.createFrom(event, componentLocation,
+        component, exception, MessageProcessorNotification.MESSAGE_PROCESSOR_POST_INVOKE);
+    OpenTelemetryConnection connection = mock(OpenTelemetryConnection.class);
+
+    MuleNotificationProcessor notificationProcessor = new MuleNotificationProcessor();
+
+    List<MuleComponent> skippedProcessors = new ArrayList<>();
+    skippedProcessors.add(new MuleComponent("mule", "logger"));
+    TraceLevelConfiguration traceLevelConfiguration = new TraceLevelConfiguration(true, skippedProcessors);
+
+    notificationProcessor.init(() -> connection, traceLevelConfiguration);
+    notificationProcessor.handleProcessorStartEvent(notification);
+
+    verifyZeroInteractions(connection);
+  }
+
+  @Test
+  public void handleProcessorStartEvent_withSkipProcessorSpansByNamespace() {
+    Event event = mock(Event.class);
+    when(event.getCorrelationId()).thenReturn("testCorrelationId");
+    Message message = getMessage(null);
+    when(event.getMessage()).thenReturn(message);
+    ComponentLocation componentLocation = getComponentLocation("mule", "logger");
+    Component component = getComponent(componentLocation, Collections.emptyMap(), "mule", "logger");
+    Exception exception = mock(Exception.class);
+    MessageProcessorNotification notification = MessageProcessorNotification.createFrom(event, componentLocation,
+        component, exception, MessageProcessorNotification.MESSAGE_PROCESSOR_POST_INVOKE);
+    OpenTelemetryConnection connection = mock(OpenTelemetryConnection.class);
+
+    MuleNotificationProcessor notificationProcessor = new MuleNotificationProcessor();
+
+    List<MuleComponent> skippedProcessors = new ArrayList<>();
+    skippedProcessors.add(new MuleComponent("mule", "*"));
+    TraceLevelConfiguration traceLevelConfiguration = new TraceLevelConfiguration(true, skippedProcessors);
+
+    notificationProcessor.init(() -> connection, traceLevelConfiguration);
+    notificationProcessor.handleProcessorStartEvent(notification);
+
+    verifyZeroInteractions(connection);
+  }
+
+  @Test
   public void handleProcessorEndEvent_withDisabledProcessorSpans() {
 
     Event event = mock(Event.class);
@@ -55,4 +110,5 @@ public class MuleNotificationProcessorTest extends AbstractProcessorComponentTes
 
     verifyZeroInteractions(connection);
   }
+
 }

--- a/src/test/resources/mule-opentelemetry-processor-enabled.xml
+++ b/src/test/resources/mule-opentelemetry-processor-enabled.xml
@@ -1,25 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<mule xmlns:opentelemetry="http://www.mulesoft.org/schema/mule/opentelemetry" xmlns:http="http://www.mulesoft.org/schema/mule/http"
+<mule xmlns:os="http://www.mulesoft.org/schema/mule/os" xmlns:opentelemetry="http://www.mulesoft.org/schema/mule/opentelemetry" xmlns:http="http://www.mulesoft.org/schema/mule/http"
 	xmlns="http://www.mulesoft.org/schema/mule/core"
 	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
 http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
-http://www.mulesoft.org/schema/mule/opentelemetry http://www.mulesoft.org/schema/mule/opentelemetry/current/mule-opentelemetry.xsd">
+http://www.mulesoft.org/schema/mule/opentelemetry http://www.mulesoft.org/schema/mule/opentelemetry/current/mule-opentelemetry.xsd
+http://www.mulesoft.org/schema/mule/os http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
 	<http:listener-config name="HTTP_Listener_config" doc:name="HTTP Listener config" doc:id="79881531-bfaa-49fd-8227-b67e35d64cf8" >
 		<http:listener-connection host="0.0.0.0" port="${http.port}" />
 	</http:listener-config>
 
+
+
+	<os:object-store name="Object_store" doc:name="Object store" doc:id="df3c6709-b188-4756-a0d8-e580e16dc9d1" />
 	<opentelemetry:config name="OpenTelemetry_Config" doc:name="OpenTelemetry Config"
 						  doc:id="91477cb5-36f7-48ad-90b7-c339af87b408"
 						  serviceName="api-app-1"
 						  spanAllProcessors="true">
-		<opentelemetry:exporter >
-			<opentelemetry:logging-exporter logPrefix="test-log" />
-		</opentelemetry:exporter>
 		<opentelemetry:resource-attributes >
 			<opentelemetry:attribute key="mule.env" value="Dev" />
 		</opentelemetry:resource-attributes>
+		<opentelemetry:exporter >
+			<opentelemetry:generic-exporter >
+				<opentelemetry:config-properties >
+					<opentelemetry:config-property key="otel.traces.exporter" value="delegatedLogging" />
+				</opentelemetry:config-properties>
+			</opentelemetry:generic-exporter>
+		</opentelemetry:exporter>
+<!--		<opentelemetry:ignore-mule-components>-->
+<!--			&lt;!&ndash; Mule functional test is unable to recognize `name` parameter-->
+<!--			 	keeps throwing `Parameter 'name' is required but was not found`-->
+<!--			 &ndash;&gt;-->
+<!--			<opentelemetry:mule-component name="test" namespace="db"/>-->
+<!--		</opentelemetry:ignore-mule-components>-->
 	</opentelemetry:config>
+	<flow name="otel-processor-flow" doc:id="d58f62ae-050a-4c54-8187-434673d8bcc6" >
+		<http:listener doc:name="Listener" doc:id="a10ef589-ef0d-455e-b794-61bb12e43c9e" config-ref="HTTP_Listener_config" path="/otel-processor-flow"/>
+		<logger level="INFO" doc:name="Logger" doc:id="f62676af-28bd-4a53-a503-e8016f5036e1" />
+		<os:store doc:name="Store" doc:id="18002e6a-2374-43f2-a46c-f8ebc9301e56" key="test" objectStore="Object_store"/>
+		<set-payload value="#['Hello']" doc:name="Set Payload" doc:id="110a2c1c-3824-4358-87e5-74c9c489f174" mimeType="text/plain"/>
+		<os:clear doc:name="Clear" doc:id="594dc5b4-8539-4277-b82c-fa3e2d2f9478" objectStore="Object_store"/>
+	</flow>
 	<flow name="mule-opentelemetry-app-2Flow" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
 		<http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/test"/>
 		<logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />


### PR DESCRIPTION
1. Fixes #43. Allow list of processors to disable tracing. See Trace Level documentation in Readme.

![image](https://user-images.githubusercontent.com/877286/190043716-c035f3c1-1d7a-4e8b-8b4b-f3be8ead2731.png)

- With `spanAllProcessors=true` and no ignored components - 
![image](https://user-images.githubusercontent.com/877286/190044513-2a6a369d-2b6f-4fdc-8ef7-813e159af0e0.png)

- With `spanAllProcessors=true` and following ignored component config - 
```
<opentelemetry:ignore-mule-components >
			<opentelemetry:mule-component namespace="MULE" name="LOGGER" />
			<opentelemetry:mule-component namespace="os" name="*" />
		</opentelemetry:ignore-mule-components>
```
os's store and clear processor spans are skipped due to `*` configuration -

![image](https://user-images.githubusercontent.com/877286/190044542-1cbbfa2b-c7ce-4022-900d-1638e4207d60.png)

- with `spanAllProcessors=false` 
![image](https://user-images.githubusercontent.com/877286/190044771-36551045-23a8-4dcf-9609-e47d21782d4b.png)


2. Fixes #42. Allow full disabling/turning off the tracing. See Turn Off Tracing in Readme. A new parameter on configuration and a system property is added to support disable the tracing. The first processor interceptor is refactor to use the notification processor and so respect the disabled tracing flag.
![image](https://user-images.githubusercontent.com/877286/190043783-c361e548-27e4-4ac0-ab1d-10cab30de494.png)
