### PR TITLE
Capture Mule Correlation Id in span attributes

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
@@ -2,11 +2,20 @@ package com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk;
 
 import io.opentelemetry.api.common.AttributeKey;
 
+/**
+ * This class defines Semantic attributes that are captured by opentelemetry
+ * module for Mule traces and spans.
+ */
 public class SemanticAttributes {
   private SemanticAttributes() {
   }
 
   public static final AttributeKey<String> MULE_HOME = AttributeKey.stringKey("mule.home");
+
+  /**
+   * Mule Correlation Id for the current event.
+   */
+  public static final AttributeKey<String> MULE_CORRELATION_ID = AttributeKey.stringKey("mule.correlationId");
   public static final AttributeKey<String> MULE_SERVER_ID = AttributeKey.stringKey("mule.serverId");
   public static final AttributeKey<String> MULE_CSORGANIZATION_ID = AttributeKey.stringKey("mule.csOrganization.id");
   public static final AttributeKey<String> MULE_ENVIRONMENT_NAME = AttributeKey.stringKey("mule.environment.name");

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AbstractProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AbstractProcessorComponent.java
@@ -136,6 +136,7 @@ public abstract class AbstractProcessorComponent implements ProcessorComponent {
   @Override
   public TraceComponent getStartTraceComponent(EnrichedServerNotification notification) {
     Map<String, String> tags = new HashMap<>(getProcessorCommonTags(notification));
+    tags.put(MULE_CORRELATION_ID.getKey(), notification.getEvent().getCorrelationId());
     tags.putAll(getAttributes(notification.getInfo().getComponent(),
         notification.getEvent().getMessage().getAttributes()));
     return TraceComponent.newBuilder(notification.getComponent().getLocation().getLocation())

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/FlowProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/FlowProcessorComponent.java
@@ -53,6 +53,7 @@ public class FlowProcessorComponent extends AbstractProcessorComponent {
     Map<String, String> tags = new HashMap<>();
     tags.put(MULE_APP_FLOW_NAME.getKey(), notification.getResourceIdentifier());
     tags.put(MULE_SERVER_ID.getKey(), notification.getServerId());
+    tags.put(MULE_CORRELATION_ID.getKey(), notification.getEvent().getCorrelationId());
 
     builder.withTags(tags)
         .withTransactionId(getTransactionId(notification))

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryHttpTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryHttpTest.java
@@ -144,7 +144,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .hasSize(1)
         .element(0)
         .extracting("attributes", as(InstanceOfAssertFactories.map(String.class, Object.class)))
-        .hasSize(12)
+        .hasSize(13)
         .containsEntry("mule.app.flow.name", "mule-opentelemetry-app-requester-remote")
         .containsKey("mule.serverId")
         .containsEntry("http.scheme", "http")
@@ -153,6 +153,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .containsEntry("mule.app.flow.source.name", "listener")
         .containsEntry("mule.app.flow.source.namespace", "http")
         .containsEntry("mule.app.flow.source.configRef", "HTTP_Listener_config")
+        .containsKey("mule.correlationId")
         .containsKey("http.user_agent")
         .hasEntrySatisfying("http.host",
             value -> assertThat(value.toString()).startsWith("localhost:"))

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponentTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponentTest.java
@@ -136,13 +136,14 @@ public class HttpProcessorComponentTest extends AbstractProcessorComponentTest {
         .extracting("spanName", "location", "spanKind")
         .containsExactly("/test", componentLocation.getLocation(), SpanKind.CLIENT);
     assertThat(endTraceComponent.getTags())
-        .hasSize(6)
+        .hasSize(7)
         .containsEntry("http.method", "GET")
         .containsEntry("mule.app.processor.configRef", "test-config")
         .containsEntry("http.route", "/test")
         .containsEntry("mule.app.processor.docName", "HTTP Request")
         .containsEntry("mule.app.processor.name", "request")
-        .containsEntry("mule.app.processor.namespace", "http");
+        .containsEntry("mule.app.processor.namespace", "http")
+        .containsEntry("mule.correlationId", "testCorrelationId");
   }
 
   @Test


### PR DESCRIPTION
Captures Mule event correlation id in root span and processor span attribute `mule.correlationId`.