### PR TITLE
Update Mule Resource attributes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,6 +99,7 @@ Extension is aware of https://help.mulesoft.com/s/article/CloudHub-Reserved-Prop
     "mule.app.domain": "mule-opentelemetry-app",
     "mule.app.fullDomain": "mule-opentelemetry-app.us-w2.cloudhub.io",
     "mule.csOrganization.id": "f2ea2cb4-c600-gh87-gg78-e952ff5591ee",
+    "mule.organization.id": "f2ea2cb4-c600-gh87-gg78-e952ff5591ee",
     "mule.env": "Dev",
     "mule.environment.id": "c06ef9b7-19c0-ss78-kk44-598058b20aad",
     "mule.environment.type": "sandbox",
@@ -106,6 +107,8 @@ Extension is aware of https://help.mulesoft.com/s/article/CloudHub-Reserved-Prop
     "mule.worker.id": "0"
 }
 ----
+
+NOTE:  CloudHub does not define any property for organization id. `mule.organization.id` refers to value of a system property `organization.id` if present, otherwise it will be same as `csOrganization.id` defined by CloudHub.
 
 === Exporters
 

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResource.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResource.java
@@ -35,11 +35,7 @@ public class MuleResource {
     AttributesBuilder builder = Attributes.builder();
     addAttribute("mule.home", builder, MULE_HOME);
     addAttribute("csorganization.id", builder, MULE_CSORGANIZATION_ID);
-    if (System.getProperties().containsKey("organization.id")) {
-      addAttribute("organization.id", builder, MULE_ORGANIZATION_ID);
-    } else {
-      addAttribute("csorganization.id", builder, MULE_ORGANIZATION_ID);
-    }
+    addAttribute("csorganization.id", builder, MULE_ORGANIZATION_ID);
     addAttribute("environment.id", builder, MULE_ENVIRONMENT_ID);
     addAttribute("environment.type", builder, MULE_ENVIRONMENT_TYPE);
     addAttribute("worker.id", builder, MULE_WORKER_ID);

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResource.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResource.java
@@ -26,24 +26,45 @@ public class MuleResource {
     INSTANCE = buildResource();
   }
 
+  /**
+   * Builds Mule Resource instance by extracting Mule related system properties.
+   * 
+   * @return {@link Resource} populated with mule attributes
+   */
   private static Resource buildResource() {
     AttributesBuilder builder = Attributes.builder();
     addAttribute("mule.home", builder, MULE_HOME);
     addAttribute("csorganization.id", builder, MULE_CSORGANIZATION_ID);
+    if (System.getProperties().containsKey("organization.id")) {
+      addAttribute("organization.id", builder, MULE_ORGANIZATION_ID);
+    } else {
+      addAttribute("csorganization.id", builder, MULE_ORGANIZATION_ID);
+    }
     addAttribute("environment.id", builder, MULE_ENVIRONMENT_ID);
     addAttribute("environment.type", builder, MULE_ENVIRONMENT_TYPE);
     addAttribute("worker.id", builder, MULE_WORKER_ID);
     addAttribute("domain", builder, MULE_APP_DOMAIN);
     addAttribute("fullDomain", builder, MULE_APP_FULL_DOMAIN);
     addAttribute("application.aws.region", builder, MULE_ENVIRONMENT_AWS_REGION);
-    addAttribute("mule.env", builder, MULE_ENVIRONMENT_NAME);
     Attributes build = builder.build();
     return Resource.create(build);
   }
 
-  private static void addAttribute(String key, AttributesBuilder builder,
+  /**
+   * If given system property exists, this will set its value as an attribute to
+   * provided {@link AttributesBuilder}.
+   * 
+   * @param sysProperty
+   *            Name of the system property to search for.
+   * @param builder
+   *            {@link AttributesBuilder} instance to add attribute
+   * @param attributeKey
+   *            {@link AttributeKey} to use for setting attribute in given
+   *            {@link AttributesBuilder}
+   */
+  private static void addAttribute(String sysProperty, AttributesBuilder builder,
       AttributeKey<String> attributeKey) {
-    String value = System.getProperty(key);
+    String value = System.getProperty(sysProperty);
     if (value != null) {
       builder.put(attributeKey, value);
     }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
@@ -2,37 +2,117 @@ package com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk;
 
 import io.opentelemetry.api.common.AttributeKey;
 
-public class SemanticAttributes {
+/**
+ * Defines the attribute keys to be used when capturing mule related span
+ * attributes.
+ */
+public final class SemanticAttributes {
   private SemanticAttributes() {
   }
 
+  /**
+   * Absolute path to mule installation.
+   */
   public static final AttributeKey<String> MULE_HOME = AttributeKey.stringKey("mule.home");
+
+  /**
+   * Mule Server Id that is processing current request.
+   */
   public static final AttributeKey<String> MULE_SERVER_ID = AttributeKey.stringKey("mule.serverId");
   public static final AttributeKey<String> MULE_CSORGANIZATION_ID = AttributeKey.stringKey("mule.csOrganization.id");
-  public static final AttributeKey<String> MULE_ENVIRONMENT_NAME = AttributeKey.stringKey("mule.environment.name");
+
+  /**
+   * Most of the Mule users are familiar with organization id instead of
+   * CSORGANIZATION ID.
+   * CloudHub does not define any property for organization id.
+   * This should refer to a system property `organization.id` if present,
+   * otherwise `csOrganization.id`.
+   */
+  public static final AttributeKey<String> MULE_ORGANIZATION_ID = AttributeKey.stringKey("mule.organization.id");
+
+  /**
+   * Mule Environment ID. See <a src=
+   * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
+   */
   public static final AttributeKey<String> MULE_ENVIRONMENT_ID = AttributeKey.stringKey("mule.environment.id");
+
+  /**
+   * Mule Environment Type - eg. sandbox or production. See <a src=
+   * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
+   */
   public static final AttributeKey<String> MULE_ENVIRONMENT_TYPE = AttributeKey.stringKey("mule.environment.type");
+
+  /**
+   * AWS Region in which Application is deployed in. See <a src=
+   * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
+   */
   public static final AttributeKey<String> MULE_ENVIRONMENT_AWS_REGION = AttributeKey
       .stringKey("mule.environment.awsRegion");
+
+  /**
+   * Mule CloudHub Worker id that is processing current request. See <a src=
+   * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
+   */
   public static final AttributeKey<String> MULE_WORKER_ID = AttributeKey.stringKey("mule.worker.id");
 
+  /**
+   * Mule Processor Name. For example `http:request` processor will have `request`
+   * as processor name.
+   */
   public static final AttributeKey<String> MULE_APP_PROCESSOR_NAME = AttributeKey
       .stringKey("mule.app.processor.name");
+
+  /**
+   * XML Namespace of the Mule processor. For example `http:request` processor
+   * will have `http` as processor namespace.
+   */
   public static final AttributeKey<String> MULE_APP_PROCESSOR_NAMESPACE = AttributeKey
       .stringKey("mule.app.processor.namespace");
+
+  /**
+   * Documented name of the processor. Usually, the value of `doc:name` attribute
+   * on processor.
+   */
   public static final AttributeKey<String> MULE_APP_PROCESSOR_DOC_NAME = AttributeKey
       .stringKey("mule.app.processor.docName");
+
+  /**
+   * Name of the configuration element, if exists on the processor. Usually, the
+   * value of `configRef` attribute on processor.
+   */
   public static final AttributeKey<String> MULE_APP_PROCESSOR_CONFIG_REF = AttributeKey
       .stringKey("mule.app.processor.configRef");
   public static final AttributeKey<String> MULE_APP_FLOW_NAME = AttributeKey.stringKey("mule.app.flow.name");
+
+  /**
+   * Name of the configuration element used by the flow source component. Usually,
+   * the value of `configRef` attribute on source.
+   */
   public static final AttributeKey<String> MULE_APP_FLOW_SOURCE_CONFIG_REF = AttributeKey
       .stringKey("mule.app.flow.source.configRef");
+  /**
+   * XML Namespace of the Source component. For example `http:listener` source
+   * will have `http` as the namespace.
+   */
   public static final AttributeKey<String> MULE_APP_FLOW_SOURCE_NAMESPACE = AttributeKey
       .stringKey("mule.app.flow.source.namespace");
+
+  /**
+   * Mule Flow Source's Name. For example `http:listener` source will have
+   * `listener` as the name.
+   */
   public static final AttributeKey<String> MULE_APP_FLOW_SOURCE_NAME = AttributeKey
       .stringKey("mule.app.flow.source.name");
 
+  /**
+   * Application Name. See <a src=
+   * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
+   */
   public static final AttributeKey<String> MULE_APP_DOMAIN = AttributeKey.stringKey("mule.app.domain");
+  /**
+   * Full DNS of application. See <a src=
+   * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
+   */
   public static final AttributeKey<String> MULE_APP_FULL_DOMAIN = AttributeKey.stringKey("mule.app.fullDomain");
 
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
@@ -29,9 +29,6 @@ public final class SemanticAttributes {
   /**
    * Most of the Mule users are familiar with organization id instead of
    * CSORGANIZATION ID.
-   * CloudHub does not define any property for organization id.
-   * This should refer to a system property `organization.id` if present,
-   * otherwise `csOrganization.id`.
    */
   public static final AttributeKey<String> MULE_ORGANIZATION_ID = AttributeKey.stringKey("mule.organization.id");
 

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResourceProviderTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResourceProviderTest.java
@@ -34,13 +34,46 @@ public class MuleResourceProviderTest {
     assertThat(resource.getAttributes().asMap())
         .containsEntry(MULE_HOME, "/home/mule")
         .containsEntry(MULE_CSORGANIZATION_ID, "MULE_CSORGANIZATION_ID")
+        .containsEntry(MULE_ORGANIZATION_ID, "MULE_CSORGANIZATION_ID")
         .containsEntry(MULE_ENVIRONMENT_ID, "MULE_ENVIRONMENT_ID")
         .containsEntry(MULE_ENVIRONMENT_TYPE, "MULE_ENVIRONMENT_TYPE")
         .containsEntry(MULE_WORKER_ID, "MULE_WORKER_ID")
         .containsEntry(MULE_APP_DOMAIN, "MULE_APP_DOMAIN")
         .containsEntry(MULE_APP_FULL_DOMAIN, "MULE_APP_FULL_DOMAIN")
-        .containsEntry(MULE_ENVIRONMENT_AWS_REGION, "MULE_APP_AWS_REGION")
-        .containsEntry(MULE_ENVIRONMENT_NAME, "MULE_ENV");
+        .containsEntry(MULE_ENVIRONMENT_AWS_REGION, "MULE_APP_AWS_REGION");
+    props.forEach((key, value) -> System.clearProperty(key.toString()));
+  }
+
+  @Test
+  public void createResource_withOrganizationId() {
+    Properties props = new Properties();
+    props.setProperty("mule.home", "/home/mule");
+    props.setProperty("csorganization.id", "MULE_CSORGANIZATION_ID");
+    props.setProperty("organization.id", "MULE_ORGANIZATION_ID");
+    props.setProperty("environment.id", "MULE_ENVIRONMENT_ID");
+    props.setProperty("environment.type", "MULE_ENVIRONMENT_TYPE");
+    props.setProperty("worker.id", "MULE_WORKER_ID");
+    props.setProperty("domain", "MULE_APP_DOMAIN");
+    props.setProperty("fullDomain", "MULE_APP_FULL_DOMAIN");
+    props.setProperty("application.aws.region", "MULE_APP_AWS_REGION");
+    props.setProperty("mule.env", "MULE_ENV");
+    props.forEach((key, value) -> System.setProperty(key.toString(), value.toString()));
+    MuleResource.refresh(); // Ensure the static map is reloaded
+    MuleResourceProvider provider = new MuleResourceProvider();
+    ConfigProperties configProperties = Mockito.mock(ConfigProperties.class);
+    Resource resource = provider.createResource(configProperties);
+    assertThat(resource)
+        .isNotNull();
+    assertThat(resource.getAttributes().asMap())
+        .containsEntry(MULE_HOME, "/home/mule")
+        .containsEntry(MULE_CSORGANIZATION_ID, "MULE_CSORGANIZATION_ID")
+        .containsEntry(MULE_ORGANIZATION_ID, "MULE_ORGANIZATION_ID")
+        .containsEntry(MULE_ENVIRONMENT_ID, "MULE_ENVIRONMENT_ID")
+        .containsEntry(MULE_ENVIRONMENT_TYPE, "MULE_ENVIRONMENT_TYPE")
+        .containsEntry(MULE_WORKER_ID, "MULE_WORKER_ID")
+        .containsEntry(MULE_APP_DOMAIN, "MULE_APP_DOMAIN")
+        .containsEntry(MULE_APP_FULL_DOMAIN, "MULE_APP_FULL_DOMAIN")
+        .containsEntry(MULE_ENVIRONMENT_AWS_REGION, "MULE_APP_AWS_REGION");
     props.forEach((key, value) -> System.clearProperty(key.toString()));
   }
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResourceProviderTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResourceProviderTest.java
@@ -43,37 +43,4 @@ public class MuleResourceProviderTest {
         .containsEntry(MULE_ENVIRONMENT_AWS_REGION, "MULE_APP_AWS_REGION");
     props.forEach((key, value) -> System.clearProperty(key.toString()));
   }
-
-  @Test
-  public void createResource_withOrganizationId() {
-    Properties props = new Properties();
-    props.setProperty("mule.home", "/home/mule");
-    props.setProperty("csorganization.id", "MULE_CSORGANIZATION_ID");
-    props.setProperty("organization.id", "MULE_ORGANIZATION_ID");
-    props.setProperty("environment.id", "MULE_ENVIRONMENT_ID");
-    props.setProperty("environment.type", "MULE_ENVIRONMENT_TYPE");
-    props.setProperty("worker.id", "MULE_WORKER_ID");
-    props.setProperty("domain", "MULE_APP_DOMAIN");
-    props.setProperty("fullDomain", "MULE_APP_FULL_DOMAIN");
-    props.setProperty("application.aws.region", "MULE_APP_AWS_REGION");
-    props.setProperty("mule.env", "MULE_ENV");
-    props.forEach((key, value) -> System.setProperty(key.toString(), value.toString()));
-    MuleResource.refresh(); // Ensure the static map is reloaded
-    MuleResourceProvider provider = new MuleResourceProvider();
-    ConfigProperties configProperties = Mockito.mock(ConfigProperties.class);
-    Resource resource = provider.createResource(configProperties);
-    assertThat(resource)
-        .isNotNull();
-    assertThat(resource.getAttributes().asMap())
-        .containsEntry(MULE_HOME, "/home/mule")
-        .containsEntry(MULE_CSORGANIZATION_ID, "MULE_CSORGANIZATION_ID")
-        .containsEntry(MULE_ORGANIZATION_ID, "MULE_ORGANIZATION_ID")
-        .containsEntry(MULE_ENVIRONMENT_ID, "MULE_ENVIRONMENT_ID")
-        .containsEntry(MULE_ENVIRONMENT_TYPE, "MULE_ENVIRONMENT_TYPE")
-        .containsEntry(MULE_WORKER_ID, "MULE_WORKER_ID")
-        .containsEntry(MULE_APP_DOMAIN, "MULE_APP_DOMAIN")
-        .containsEntry(MULE_APP_FULL_DOMAIN, "MULE_APP_FULL_DOMAIN")
-        .containsEntry(MULE_ENVIRONMENT_AWS_REGION, "MULE_APP_AWS_REGION");
-    props.forEach((key, value) -> System.clearProperty(key.toString()));
-  }
 }


### PR DESCRIPTION
- Removes the mule.env attribute. This is a user-defined attribute and not present on CH.
- Introduce mule.organization.id which is more mule- user friendly name. Value is same as CS Organization Id defined by CloudHub.