### PR TITLE
feat: upgrade otel to 1.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <mule.maven.plugin.version>3.2.7</mule.maven.plugin.version>
         <build.plugins.plugin.version>2.3.2</build.plugins.plugin.version>
-        <opentelemetry.version>1.10.1</opentelemetry.version>
+        <opentelemetry.version>1.19.0</opentelemetry.version>
         <munit.extensions.maven.plugin.version>1.1.2</munit.extensions.maven.plugin.version>
         <munit.version>2.3.8</munit.version>
     </properties>
@@ -280,6 +280,16 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
             <version>${opentelemetry.version}-alpha</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-sdk-metrics</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-sdk-logs</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -290,6 +300,12 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
             <version>${opentelemetry.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-sdk-metrics</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -299,11 +315,6 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
-            <version>${opentelemetry.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp-http-trace</artifactId>
             <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgrade OpenTelemetry dependency to latest - 1.19.0. This version includes Metrics as a released capability. Excluding metrics and logs related artifacts since we don't support it in the module.