### PR TITLE
feat: use maven artifact id and version for instrumentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,27 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-module-version-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources-filtered</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/DelegatedLoggingSpanExporterProvider.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/DelegatedLoggingSpanExporterProvider.java
@@ -50,6 +50,8 @@ public class DelegatedLoggingSpanExporterProvider implements ConfigurableSpanExp
         span.setSpanKind(spanData.getKind().toString());
         span.setTraceId(spanData.getTraceId());
         span.setSpanStatus(spanData.getStatus().getStatusCode().name());
+        span.setInstrumentationName(spanData.getInstrumentationLibraryInfo().getName());
+        span.setInstrumentationVersion(spanData.getInstrumentationLibraryInfo().getVersion());
         Map<String, Object> attributes = new HashMap<>();
         spanData.getAttributes().forEach((key, value) -> attributes.put(key.getKey(), value));
         span.setAttributes(attributes);
@@ -75,12 +77,30 @@ public class DelegatedLoggingSpanExporterProvider implements ConfigurableSpanExp
   }
 
   public static class Span {
+    private String instrumentationName;
+    private String instrumentationVersion;
     private String spanName;
     private String traceId;
     private String spanId;
     private String spanKind;
     private String spanStatus;
     private Map<String, Object> attributes;
+
+    public String getInstrumentationName() {
+      return instrumentationName;
+    }
+
+    public void setInstrumentationName(String instrumentationName) {
+      this.instrumentationName = instrumentationName;
+    }
+
+    public String getInstrumentationVersion() {
+      return instrumentationVersion;
+    }
+
+    public void setInstrumentationVersion(String instrumentationVersion) {
+      this.instrumentationVersion = instrumentationVersion;
+    }
 
     public String getSpanStatus() {
       return spanStatus;
@@ -132,7 +152,10 @@ public class DelegatedLoggingSpanExporterProvider implements ConfigurableSpanExp
 
     @Override
     public String toString() {
-      return "Span{" +
+      return "Tracing{" +
+          "instrumentationName='" + instrumentationName + '\'' +
+          ", instrumentationVersion='" + instrumentationVersion + '\'' +
+          "}, Span{" +
           "spanName='" + spanName + '\'' +
           ", traceId='" + traceId + '\'' +
           ", spanId='" + spanId + '\'' +

--- a/src/main/resources-filtered/mule-opentelemetry-module.properties
+++ b/src/main/resources-filtered/mule-opentelemetry-module.properties
@@ -1,0 +1,2 @@
+module.version=${project.version}
+module.artifactId=${project.artifactId}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryHttpTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryHttpTest.java
@@ -45,6 +45,25 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
   }
 
   @Test
+  public void testInstrumentationMetadataDetails() throws Exception {
+    sendRequest(CORRELATION_ID, "test", 200);
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanExporter.spanQueue)
+        .hasSize(1));
+    assertThat(DelegatedLoggingSpanExporter.spanQueue)
+        .element(0)
+        .extracting("instrumentationVersion", InstanceOfAssertFactories.STRING)
+        .isNotNull()
+        .isNotEmpty()
+        .as("Version loaded from properties")
+        .isNotEqualTo("0.0.1-DEV");
+    assertThat(DelegatedLoggingSpanExporter.spanQueue)
+        .element(0)
+        .extracting("instrumentationName", InstanceOfAssertFactories.STRING)
+        .isNotNull()
+        .isEqualTo("mule-opentelemetry-module");
+  }
+
+  @Test
   public void testHttpTracing_WithErrorResponseStatusCode() throws Exception {
     sendRequest(CORRELATION_ID, "/test/error-status", 500);
     await().untilAsserted(() -> assertThat(DelegatedLoggingSpanExporter.spanQueue)


### PR DESCRIPTION
Use maven artifact id and version as the instrumentation name and version when creating OpenTelemetry Tracer instance. Leverages [Maven Resource Filtering](https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html) to write artifact id and version to a property file and later reads it from this properties file.
