### PR TITLE
feat: add custom tags to otel trace

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -225,6 +225,34 @@ To disable span generation for all processors in a specific namespace, set the `
 <opentelemetry:mule-component namespace="os" name="*" />
 ----
 
+=== Custom Tags
+In addition to all the trace attributes captured by the module, it is possible to add custom tags to the current trace using an operation `opentelemetry:add-custom-tags`.
+
+WARNING: All custom tag keys are transformed to `custom.{keyName}`. This also prevents accidentally overriding other standard keys-value pairs in trace tags. Depending on the APM (elastic, etc.) you use, they may be displayed differently. For example, elastic will display them as `label.custom_{keyName}`.
+
+These could be any business data that you may want to capture as a part of your telemetry data. For example, an order number for an order processing transaction.
+
+[source,xml]
+.Adding custom tag from variable
+----
+    <opentelemetry:add-custom-tags doc:name="Add Custom Tags"
+                config-ref="OpenTelemetry_Config">
+        <opentelemetry:tags >
+            <opentelemetry:tag key="orderNumber" value="#[vars.orderNumber]"/>
+        </opentelemetry:tags>
+    </opentelemetry:add-custom-tags>
+----
+
+You can also use dataweave to set the tags.
+
+[source,xml]
+.Adding custom tags as DataWeave map
+----
+    <opentelemetry:add-custom-tags doc:name="Add Custom Tags"
+                config-ref="OpenTelemetry_Config"
+                tags="#[output java --- {orderNumber: payload.orderNumber}]" />
+----
+
 == Context Propagation
 
 https://www.w3.org/TR/trace-context/#trace-context-http-headers-format[W3C Trace Context] and https://www.w3.org/TR/baggage/#baggage-http-header-format[W3C Baggage Context] are supported for incoming requests.

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryOperations.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryOperations.java
@@ -17,4 +17,27 @@ public class OpenTelemetryOperations {
     String transactionId = correlationInfo.getCorrelationId();
     return openTelemetryConnection.getTraceContext(transactionId);
   }
+
+  /**
+   * Add custom tags to an ongoing trace transaction. The tags will be added as
+   * attributes to the root span of this transaction.
+   * If the transaction's root span previously contained a mapping for the key,
+   * the old value is replaced by the new value.
+   *
+   * @param openTelemetryConnection
+   *            {@link OpenTelemetryConnection} provided by the SDK
+   * @param tags
+   *            {@link Map} of {@link String} Keys and {@link String} Values
+   *            containing the tags. Behavior of null values in the map is
+   *            undefined and not recommended.
+   * @param correlationInfo
+   *            {@link CorrelationInfo} from the runtime
+   */
+  @DisplayName("Add Custom Tags")
+  public void addCustomTags(@Connection OpenTelemetryConnection openTelemetryConnection,
+      Map<String, String> tags,
+      CorrelationInfo correlationInfo) {
+    openTelemetryConnection.getTransactionStore().addTransactionTags(correlationInfo.getCorrelationId(), "custom",
+        tags);
+  }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/TransactionStore.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/TransactionStore.java
@@ -4,6 +4,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
+import java.util.Map;
 import java.util.function.Consumer;
 import org.mule.runtime.api.event.Event;
 
@@ -46,11 +47,26 @@ public interface TransactionStore {
   void startTransaction(String transactionId, String rootFlowName, SpanBuilder rootFlowSpan);
 
   /**
+   * Add custom tags to an existing transaction.
+   *
+   * @param transactionId
+   *            A unique transaction id within the context of an application. Eg.
+   *            Correlation id.
+   * @param tagPrefix
+   * @param tags
+   *            {@link Map} of {@link String} Keys and {@link String} Values
+   *            containing the tags.
+   */
+  void addTransactionTags(String transactionId, String tagPrefix, Map<String, String> tags);
+
+  /**
    * Get the {@link Context} of the initiating flow span. This may be required to
    * propagate
    * context for a given transaction.
    *
    * @param transactionId
+   *            A unique transaction id within the context of an application. Eg.
+   *            Correlation id.
    * @return {@link Context}
    */
   Context getTransactionContext(String transactionId);
@@ -59,6 +75,8 @@ public interface TransactionStore {
    * Get the Trace Id associated the transaction
    *
    * @param transactionId
+   *            A unique transaction id within the context of an application. Eg.
+   *            Correlation id.
    * @return traceId
    */
   public String getTraceIdForTransaction(String transactionId);

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsTest.java
@@ -1,0 +1,54 @@
+package com.avioconsulting.mule.opentelemetry;
+
+import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.DelegatedLoggingSpanExporterProvider.DelegatedLoggingSpanExporter;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.Test;
+import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.core.api.event.CoreEvent;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class MuleOpenTelemetryOperationsTest extends AbstractMuleArtifactTraceTest {
+
+  @Override
+  protected String getConfigFile() {
+    return "mule-opentelemetry-operations.xml";
+  }
+
+  @Test
+  public void testHttpTracing_WithCustomTags() throws Exception {
+    sendRequest(CORRELATION_ID, "tags", 200, Collections.emptyMap(),
+        Collections.singletonMap("orderId", "order123"));
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanExporter.spanQueue)
+        .hasSize(1)
+        .element(0)
+        .extracting("spanName", "spanKind", "spanStatus")
+        .containsOnly("/tags", "SERVER", "UNSET"));
+    assertThat(DelegatedLoggingSpanExporter.spanQueue)
+        .element(0)
+        .extracting("attributes", InstanceOfAssertFactories.map(String.class, String.class))
+        .containsEntry("http.status_code", "200")
+        .containsEntry("custom.orderId", "order123")
+        .containsEntry("custom.quantity", "20")
+        .containsEntry("custom.payload", "Tag Payload");
+  }
+
+  @Test
+  public void testHttpTracing_GetTraceContext() throws Exception {
+    CoreEvent coreEvent = runFlow("mule-opentelemetry-get-trace-context");
+    assertThat(coreEvent.getVariables())
+        .as("Variables that should contain OTEL injected context")
+        .containsKeys("OTEL_TRACE_CONTEXT", "OTEL_CONTEXT");
+    TypedValue<Map<String, String>> otel_trace_context_from_interceptor = (TypedValue<Map<String, String>>) coreEvent
+        .getVariables().get("OTEL_TRACE_CONTEXT");
+    TypedValue<Map<String, String>> otel_context_from_operation = (TypedValue<Map<String, String>>) coreEvent
+        .getVariables().get("OTEL_CONTEXT");
+    assertThat(otel_trace_context_from_interceptor.getValue())
+        .containsExactlyEntriesOf(otel_context_from_operation.getValue());
+  }
+
+}

--- a/src/test/resources/mule-opentelemetry-operations.xml
+++ b/src/test/resources/mule-opentelemetry-operations.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:opentelemetry="http://www.mulesoft.org/schema/mule/opentelemetry" xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/opentelemetry http://www.mulesoft.org/schema/mule/opentelemetry/current/mule-opentelemetry.xsd">
+
+    <import file="global-common.xml"/>
+
+    <flow name="mule-opentelemetry-custom-tags" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+        <http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/tags"/>
+        <logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
+        <opentelemetry:add-custom-tags doc:name="Add custom tags" doc:id="3e5c38f9-a197-4ee6-bb1a-9419e69f9fc5" config-ref="OpenTelemetry_Config">
+            <opentelemetry:tags>
+                <opentelemetry:tag key="orderId" value="#[attributes.queryParams.orderId]" />
+                <opentelemetry:tag key="quantity" value="20" />
+            </opentelemetry:tags>
+        </opentelemetry:add-custom-tags>
+        <set-variable variableName="httpStatus" value="#[200]"/>
+        <set-payload value="Tag Payload" doc:name="Set Payload" doc:id="6bb91307-b173-4256-8c64-491dad475af7" />
+        <opentelemetry:add-custom-tags doc:name="Add custom tags" doc:id="937c3f56-019e-4f69-b3bf-1c9dd7ac6988" config-ref="OpenTelemetry_Config">
+            <opentelemetry:tags >
+                <opentelemetry:tag key="payload" value="#[payload]" />
+            </opentelemetry:tags>
+        </opentelemetry:add-custom-tags>
+        <logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
+    </flow>
+
+    <flow name="mule-opentelemetry-get-trace-context" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+        <http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/tracecontext"/>
+        <logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
+        <opentelemetry:get-trace-context doc:name="Get Trace Context" doc:id="50381ac8-89c8-4993-abdd-7d1af518ea2d" config-ref="OpenTelemetry_Config" target="OTEL_CONTEXT"/>
+        <set-variable variableName="httpStatus" value="#[200]"/>
+        <set-payload value="#[output json --- vars.OTEL_CONTEXT]" doc:name="Set Payload" doc:id="110a2c1c-3824-4358-87e5-74c9c489f174" mimeType="text/plain" />
+        <logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
+    </flow>
+
+</mule>


### PR DESCRIPTION
Resolves #41 

Introduces a new operation `opentelemetry:add-custom-tags` to add tags to root trace. See updates to README for more details.

All custom tag keys are transformed to `custom.{keyName}`. This also prevents accidentally overriding other standard keys-value pairs in trace tags.

```
<opentelemetry:add-custom-tags doc:name="Add Custom Tags" doc:id="6917edd0-4648-4a75-957a-bfc57b09a8c5" config-ref="OpenTelemetry_Config">
	<opentelemetry:tags >
		<opentelemetry:tag key="orderNumber" value="#[vars.orderNumber]"/>
	</opentelemetry:tags>
</opentelemetry:add-custom-tags>
```

