### PR TITLE
feat: adding tags to config spans (resolves#68)

### DIFF
--- a/src/docs/asciidoc/module-config.adoc
+++ b/src/docs/asciidoc/module-config.adoc
@@ -264,6 +264,41 @@ You can also use dataweave to set the tags.
                 tags="#[output java --- {orderNumber: payload.orderNumber}]" />
 ----
 
+=== Global Config Span tags
+Some APMs may require additional tags on spans for the correct display of traces. For example, Splunk APM can use `peer.service` on http request spans when creating inferred services in service maps.
+
+The module may not be capturing those tags out of the box but there is a way to add additional tags to the spans of components that use global configuration elements. Some examples would be `http:listener` using `http:listener-config`, `db:insert` using `db:config`.
+
+The module will recognize system properties defined with property names following the pattern `{global_config_element_name}.otel.{tag_name}` and add `{tag_name}:{property_value}` as a tag to spans generated for all components using `{global_config_element_name}` named global element.
+
+CAUTION: Any tags set using this system properties, will override module generated value for same tags.
+
+In case of Splunk, `peer.service` attribute should have the name of the remote http system being invoked. Consider following mule requester example -
+
+[source,xml]
+----
+
+    <!-- Global HTTP Request Configuration element -->
+	<http:request-config name="Remote_Request_configuration" doc:name="HTTP Request configuration"> // <1>
+		<http:request-connection host="${http.host}" port="${http.port}" />
+	</http:request-config>
+
+    <!-- Flow including http:request that references above global config -->
+	<flow name="mule-opentelemetry-app-requester-remote" >
+		<http:listener doc:name="Listener" config-ref="HTTP_Listener_config" path="/test-remote-request"/>
+		<http:request method="GET" doc:name="Request" config-ref="Remote_Request_configuration" path="/test/remote/target"/> // <2>
+		<logger level="INFO" doc:name="Logger"/>
+	</flow>
+----
+
+To add a tag `peer.service=my_remote_api` to `http:request` 's span, you can set following system property on mule runtime -
+[source,properties]
+----
+Remote_Request_configuration.otel.peer.service=my_remote_api
+----
+
+
+
 === Context Propagation
 
 This module supports context propagation in

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryAnypointMQTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryAnypointMQTest.java
@@ -31,6 +31,12 @@ public class MuleOpenTelemetryAnypointMQTest extends AbstractMuleArtifactTraceTe
   @Rule
   public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(amqPort.getNumber()));
 
+  @Override
+  protected void doSetUpBeforeMuleContextCreation() throws Exception {
+    super.doSetUpBeforeMuleContextCreation();
+    System.setProperty("Anypoint_MQ_Config.otel.mq.system.fromprop", "AnypointMQ_Sys");
+  }
+
   @Before
   public void setupMQ() {
     wireMockRule.stubFor(get(urlEqualTo(
@@ -66,7 +72,9 @@ public class MuleOpenTelemetryAnypointMQTest extends AbstractMuleArtifactTraceTe
         .containsEntry("messaging.url", "http://localhost:" + wireMockRule.port() + "/api/v1")
         .containsEntry("messaging.consumer_id", "2327057f85ab4340b2f27c7b1b20cb07")
         .containsEntry("messaging.destination", "otel-test-queue-1")
-        .containsEntry("messaging.protocol", "http");
+        .containsEntry("messaging.protocol", "http")
+        .as("System set property").containsEntry("mq.system.fromprop", "AnypointMQ_Sys");
+    ;
     if (spanKind.equalsIgnoreCase("PRODUCER")) {
       assertThat(span)
           .extracting("spanName", "spanKind", "spanStatus")

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryDBTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryDBTest.java
@@ -23,6 +23,12 @@ public class MuleOpenTelemetryDBTest extends AbstractMuleArtifactTraceTest {
 
   private static boolean dbInitialized = false;
 
+  @Override
+  protected void doSetUpBeforeMuleContextCreation() throws Exception {
+    super.doSetUpBeforeMuleContextCreation();
+    System.setProperty("Database_Config.otel.db.system.fromprop", "derby_Sys");
+  }
+
   @Before
   public void initDB() throws Exception {
     if (!dbInitialized) {
@@ -53,7 +59,8 @@ public class MuleOpenTelemetryDBTest extends AbstractMuleArtifactTraceTest {
         .containsEntry("db.system", "other_sql")
         .containsEntry("mule.app.processor.namespace", "db")
         .containsEntry("db.operation", docName.toLowerCase())
-        .containsEntry("mule.app.processor.docName", docName);
+        .containsEntry("mule.app.processor.docName", docName)
+        .as("System set property").containsEntry("db.system.fromprop", "derby_Sys");
   }
 
   @Test


### PR DESCRIPTION
See changes to src/docs/asciidoc/module-config.adoc.

Lets you add properties like - 
```
Remote_Request_configuration.otel.peer.service=my_remote_api
```

Resolves #68.
