### PR TITLE
fix: connection param handling

### DIFF
--- a/src/docs/asciidoc/module-config.adoc
+++ b/src/docs/asciidoc/module-config.adoc
@@ -371,4 +371,5 @@ Once you have configured the module in your application, there may be a need to 
 
 === Limitations
 - Automatic header/attribute injections for outbound requests is not supported
-- When using in on-premise mode, all applications deployed to the same runtime will share the same instance of OpenTelemetry configuration. It is unpredictable that which application's configuration wins. Ideally, the configuration should be same across the applications.
+- When using in *on-premise mode*, all applications deployed to the same runtime will share the same instance of OpenTelemetry configuration. It is unpredictable that which application's configuration wins. Ideally, the configuration should be same across the applications.
+- When using *mule domain projects* for global configurations, the generated spans do not include any global configuration or connection tags.

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
@@ -117,4 +117,8 @@ public final class SemanticAttributes {
    */
   public static final AttributeKey<String> MULE_APP_FULL_DOMAIN = AttributeKey.stringKey("mule.app.fullDomain");
 
+  /**
+   * Key to define datasource name for db connections
+   */
+  public static final AttributeKey<String> DB_DATASOURCE = AttributeKey.stringKey("db.datasource");
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/DBProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/DBProcessorComponent.java
@@ -1,5 +1,6 @@
 package com.avioconsulting.mule.opentelemetry.internal.processor;
 
+import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.SemanticAttributes;
 import io.opentelemetry.api.trace.SpanKind;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
@@ -48,23 +49,46 @@ public class DBProcessorComponent extends AbstractProcessorComponent {
     Map<String, String> tags = new HashMap<>();
 
     String connectionComponentName = connectionParams.get(ComponentWrapper.COMPONENT_NAME_KEY);
-    String connectionName = connectionComponentName.split("-")[0];
-    if ("generic".equalsIgnoreCase(connectionName)) {
-      connectionName = "other_sql";
+    String connectionName = "other_sql";
+    // See DB Recommended system names {@link
+    // io.opentelemetry.semconv.trace.attributes.DbSystemValues}
+    // Connection name can be null. See Issue #65 and Issue #66.
+    if (connectionComponentName != null) {
+      connectionName = connectionComponentName.substring(0, connectionComponentName.lastIndexOf("-"));
+      if ("generic".equalsIgnoreCase(connectionName) ||
+          "data-source".equalsIgnoreCase(connectionName)) {
+        connectionName = "other_sql";
+      } else {
+        if (connectionName.contains("-")) {
+          connectionName = connectionName.replace("-", "");
+        }
+      }
     }
+
     tags.put(DB_SYSTEM.getKey(), connectionName);
-    addTagIfPresent(connectionParams, "databaseName", tags, DB_NAME.getKey());
-    addTagIfPresent(connectionParams, "database", tags, DB_NAME.getKey());
+
     addTagIfPresent(connectionParams, "host", tags, NET_PEER_NAME.getKey());
     addTagIfPresent(connectionParams, "port", tags, NET_PEER_PORT.getKey());
     addTagIfPresent(connectionParams, "user", tags, DB_USER.getKey());
-    addTagIfPresent(connectionParams, "instanceName", tags, DB_MSSQL_INSTANCE_NAME.getKey());
-    addTagIfPresent(connectionParams, "instance", tags, "db.oracle.instance");
-    addTagIfPresent(connectionParams, "serviceName", tags, "db.oracle.serviceName");
-    tags.put(DB_JDBC_DRIVER_CLASSNAME.getKey(), connectionParams.get("driverClassName"));
+
     tags.put(DB_STATEMENT.getKey(), componentWrapper.getParameter("sql"));
     tags.put(DB_OPERATION.getKey(), component.getIdentifier().getName());
-    tags.put(DB_USER.getKey(), connectionParams.get("user"));
+
+    // data-source-connection
+    addTagIfPresent(connectionParams, "dataSourceRef", tags, SemanticAttributes.DB_DATASOURCE.getKey());
+    // mssql-connection
+    addTagIfPresent(connectionParams, "databaseName", tags, DB_NAME.getKey());
+    // mysql-connection
+    addTagIfPresent(connectionParams, "database", tags, DB_NAME.getKey());
+    addTagIfPresent(connectionParams, "instanceName", tags, DB_MSSQL_INSTANCE_NAME.getKey());
+
+    // oracle-connection
+    addTagIfPresent(connectionParams, "instance", tags, "db.oracle.instance");
+    addTagIfPresent(connectionParams, "serviceName", tags, "db.oracle.serviceName");
+
+    // generic
+    tags.put(DB_JDBC_DRIVER_CLASSNAME.getKey(), connectionParams.get("driverClassName"));
+
     return tags;
   }
 

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/DBProcessorComponentTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/DBProcessorComponentTest.java
@@ -1,0 +1,103 @@
+package com.avioconsulting.mule.opentelemetry.internal.processor;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mule.runtime.api.component.Component;
+import org.mule.runtime.api.component.ComponentIdentifier;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
+import org.mule.runtime.api.component.location.Location;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(JUnitParamsRunner.class)
+public class DBProcessorComponentTest extends AbstractProcessorComponentTest {
+
+  @Test
+  @Parameters({ "generic-connection, other_sql, database",
+      "my-sql-connection, mysql, database",
+      "mssql-connection, mssql, databaseName",
+      "oracle-connection, oracle, serviceName",
+      "data-source-connection, other_sql, dataSourceRef" })
+  public void testDBProcessorTagExtraction(String connectionType, String expectedDbSysName, String dbNameKey) {
+
+    ConfigurationComponentLocator componentLocator = mock(ConfigurationComponentLocator.class);
+
+    // Generic DB System
+    ComponentIdentifier identifier = getMockedIdentifier("db", connectionType);
+    ComponentLocation configComponentLocation = getComponentLocation();
+    Map<String, String> connectionConfig = new HashMap<>();
+    connectionConfig.put(dbNameKey, "testDb");
+    connectionConfig.put("host", "localhost");
+    connectionConfig.put("port", "2004");
+    connectionConfig.put("user", "test");
+    connectionConfig.put("password", "test");
+    connectionConfig.put("instanceName", "testInstanceName");
+    connectionConfig.put("instance", "testInstance");
+    connectionConfig.put("driverClassName", "testDriverClassName");
+    Component configComponent = getComponent(configComponentLocation, connectionConfig, "db", "config");
+    when(configComponent.getIdentifier()).thenReturn(identifier);
+    when(componentLocator.find(any(Location.class))).thenReturn(Optional.of(configComponent));
+
+    DBProcessorComponent dbProcessorComponent = new DBProcessorComponent();
+    dbProcessorComponent.withConfigurationComponentLocator(componentLocator);
+    ComponentLocation componentLocation = getComponentLocation();
+    Map<String, String> config = new HashMap<>();
+    config.put("sql", "select * from test");
+    config.put("config-ref", "Database_Config");
+    Component component = getComponent(componentLocation, config, "db", "select");
+
+    Map<String, String> attributes = dbProcessorComponent.getAttributes(component, null);
+
+    assertThat(attributes)
+        .containsEntry("db.system", expectedDbSysName)
+        .containsEntry("net.peer.name", "localhost")
+        .containsEntry("net.peer.port", "2004")
+        .containsEntry("db.user", "test")
+        .containsEntry("db.mssql.instance_name", "testInstanceName")
+        .containsEntry("db.oracle.instance", "testInstance")
+        .containsEntry("db.jdbc.driver_classname", "testDriverClassName");
+
+    if (dbNameKey.equalsIgnoreCase("serviceName")) {
+      assertThat(attributes)
+          .containsEntry("db.oracle.serviceName", "testDb");
+    } else if (dbNameKey.equalsIgnoreCase("dataSourceRef")) {
+      assertThat(attributes)
+          .containsEntry("db.datasource", "testDb");
+    } else {
+      assertThat(attributes)
+          .containsEntry("db.name", "testDb");
+    }
+  }
+
+  @Test
+  public void testDBProcessorTagExtraction_WhenNoParameters() {
+
+    ConfigurationComponentLocator componentLocator = mock(ConfigurationComponentLocator.class);
+    // Cannot find a connection config element using locator
+    when(componentLocator.find(any(Location.class))).thenReturn(Optional.empty());
+
+    DBProcessorComponent dbProcessorComponent = new DBProcessorComponent();
+    dbProcessorComponent.withConfigurationComponentLocator(componentLocator);
+    ComponentLocation componentLocation = getComponentLocation();
+    Map<String, String> config = new HashMap<>();
+    config.put("sql", "select * from test");
+    config.put("config-ref", "Database_Config");
+    Component component = getComponent(componentLocation, config, "db", "select");
+
+    Map<String, String> attributes = dbProcessorComponent.getAttributes(component, null);
+
+    assertThat(attributes)
+        .containsEntry("db.system", "other_sql")
+        .containsEntry("db.statement", "select * from test")
+        .containsEntry("db.operation", "select");
+  }
+}


### PR DESCRIPTION
1. Add domain configuration limitation (relates to #66 )in documentation
2. Fix database connection parameters to avoid NPE when config cannot be obtained ( fixes #65 )
3. Fix database system name for 
 **  mysql from 'my' to 'mysql'
 ** data-source from 'data' to 'other_sql'
4. Partially improves for by also capturing dataSourceRef to `db.datasource` tag (relates to #67 )
