### PR TITLE
docs: add otel version - resolves #77

### DIFF
--- a/src/docs/asciidoc/module-config.adoc
+++ b/src/docs/asciidoc/module-config.adoc
@@ -15,7 +15,7 @@ To use this extension, add following dependency to your mule application project
 <1> The latest version of the module as published on https://search.maven.org/search?q=g:com.avioconsulting%20a:mule-opentelemetry-module[Maven Central].
 
 === Auto Configuration
-Extension uses OpenTelemetry's autoconfigured SDK. In this mode, SDK will configure itself based on the environment variables.
+Extension uses OpenTelemetry SDK *v{opentelemetry-version}* in its autoconfigured mode. In this mode, SDK will configure itself based on the environment variables.
 Supported environment variable details can be seen on https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure[open-telemetry/opentelemetry-java].
 
 === Extension Configuration
@@ -124,7 +124,7 @@ Following example shows possible configuration for to send traces to Zipkin.
 
 The required Zipkin exporter dependencies must be configured as an https://docs.mulesoft.com/mule-runtime/4.4/mmp-concept#configure-plugin-dependencies[Additional Plugin Dependencies] for Mule Maven Plugin.
 
-[source, xml]
+[source, xml, subs=+macros]
 ----
 <plugin>
     <groupId>org.mule.tools.maven</groupId>
@@ -137,10 +137,15 @@ The required Zipkin exporter dependencies must be configured as an https://docs.
                 <groupId>com.avioconsulting</groupId>
                 <artifactId>mule-opentelemetry-module</artifactId>
                 <additionalDependencies>
+                <!--
+                    pass:attributes[Module uses OpenTelemetry SDK v{opentelemetry-version}.
+                     Any opentelemetry dependencies used here must be at-least v{opentelemetry-version}
+                     or a compatible one.]
+                -->
                     <dependency>
                         <groupId>io.opentelemetry</groupId>
                         <artifactId>opentelemetry-exporter-zipkin</artifactId>
-                        <version>1.10.1</version>
+                        <version>pass:a[{opentelemetry-version}]</version>
                     </dependency>
                 </additionalDependencies>
             </plugin>


### PR DESCRIPTION
Asciidoc maven plugin makes all maven properties available to use in docs with `.` replace with `-`. This change uses OpenTelemetry's version from maven property `opentelemetry.version` defined in pom.xml. 
