### PR TITLE
fix: safe parsing of httpStatus

### DIFF
--- a/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
@@ -132,7 +132,9 @@ public abstract class AbstractMuleArtifactTraceTest extends MuleArtifactFunction
     headers.forEach(getRequest::addHeader);
     try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
       try (CloseableHttpResponse response = httpClient.execute(getRequest)) {
-        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(expectedStatus);
+        if (expectedStatus != -1) {
+          assertThat(response.getStatusLine().getStatusCode()).isEqualTo(expectedStatus);
+        }
       }
     }
   }

--- a/src/test/resources/mule-opentelemetry-http.xml
+++ b/src/test/resources/mule-opentelemetry-http.xml
@@ -11,6 +11,20 @@ http://www.mulesoft.org/schema/mule/opentelemetry http://www.mulesoft.org/schema
 	<http:request-config name="INVALID_HTTP_BasePath_Request_configuration" doc:name="HTTP Request configuration" doc:id="c18eed36-eb42-4c29-abc9-9e7a2c6049e1" basePath="/api" >
 		<http:request-connection host="0.0.0.0" port="9085" />
 	</http:request-config>
+	<flow name="http-json-status" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+		<http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/test-json-status"/>
+		<logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
+		<set-payload value="Received in App2" doc:name="Set Payload" doc:id="6bb91307-b173-4256-8c64-491dad475af7" />
+		<set-variable variableName="httpStatus" value="#[output json --- 200]"/>
+		<logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
+	</flow>
+	<flow name="http-bad-status" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+		<http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/test-bad-status"/>
+		<logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
+		<set-payload value="Received in App2" doc:name="Set Payload" doc:id="6bb91307-b173-4256-8c64-491dad475af7" />
+		<set-variable variableName="httpStatus" value="#[output json --- 'NotANumber']"/>
+		<logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
+	</flow>
 	<flow name="http-wildcard-listener" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
 		<http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/test-wildcard/*"/>
 		<logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />


### PR DESCRIPTION
Safely parses httpStatus variable for HTTP Listner closing span. Can handle JSON stream as well as JAVA values.

Fixes #80 