### PR TITLE
Add SpanID to OTEL_TRACE_CONTEXT

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
@@ -129,6 +129,7 @@ public class OpenTelemetryConnection implements TraceContextHandler {
     Map<String, String> traceContext = new HashMap<>();
     traceContext.put(TransactionStore.TRACE_TRANSACTION_ID, transactionId);
     traceContext.put(TransactionStore.TRACE_ID, getTransactionStore().getTraceIdForTransaction(transactionId));
+    traceContext.put(TransactionStore.SPAN_ID, getTransactionStore().getSpanIdForTransaction(transactionId));
     logger.debug("Creating trace context for TRACE_TRANSACTION_ID=" + transactionId);
     try (Scope scope = transactionContext.makeCurrent()) {
       injectTraceContext(traceContext, HashMapTextMapSetter.INSTANCE);

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
@@ -87,6 +87,15 @@ public class InMemoryTransactionStore implements TransactionStore {
     }
   }
 
+  public String getSpanIdForTransaction(String transactionId) {
+    Optional<Transaction> transaction = getTransaction(transactionId);
+    if (transaction.isPresent()) {
+      return transaction.get().getSpanId();
+    } else {
+      return null;
+    }
+  }
+  
   @Override
   public void endTransaction(
       String transactionId,

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/Transaction.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/Transaction.java
@@ -30,4 +30,8 @@ public class Transaction implements Serializable {
   public String getTraceId() {
     return traceId;
   }
+
+  public String getSpanId() {
+    return rootFlowSpan.getSpan().getSpanContext().getSpanId();
+  }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/Transaction.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/Transaction.java
@@ -7,12 +7,14 @@ public class Transaction implements Serializable {
   private final String rootFlowName;
   private final FlowSpan rootFlowSpan;
   private final String traceId;
+  private final String spanId;
 
   public Transaction(String transactionId, String traceId, String rootFlowName, FlowSpan rootFlowSpan) {
     this.transactionId = transactionId;
     this.rootFlowName = rootFlowName;
     this.rootFlowSpan = rootFlowSpan;
     this.traceId = traceId;
+    this.spanId = rootFlowSpan.getSpan().getSpanContext().getSpanId();
   }
 
   public String getTransactionId() {
@@ -32,6 +34,6 @@ public class Transaction implements Serializable {
   }
 
   public String getSpanId() {
-    return rootFlowSpan.getSpan().getSpanContext().getSpanId();
+    return spanId;
   }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/TransactionStore.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/TransactionStore.java
@@ -14,6 +14,7 @@ public interface TransactionStore {
   String TRACE_TRANSACTION_ID = "TRACE_TRANSACTION_ID";
   String TRACE_CONTEXT_MAP_KEY = "OTEL_TRACE_CONTEXT";
   String TRACE_ID = "traceId";
+  String SPAN_ID = "spanId";
 
   /**
    * A default implementation to get a mule correlation id as a local transaction


### PR DESCRIPTION
Not sure if this is along the right lines or not, I'm a bit rusty on my Java (and was never that proficient anyway!)

This would hopefully add the Span ID to the OTEL_TRACE_CONTEXT object, so we could then include it in the log MDC (via the Tracing module), which would enable the application logs to be ingested into Dynatrace (and possibly other APM's) with the required Trace ID and Span ID for linking in their interface.

If this is not useful or anything feel free to reject or close this!
If you think it might be useful then let me know and I can try and add some documentation for it.