### PR TITLE
fix: intercept span creation

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/processor/ProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/processor/ProcessorComponent.java
@@ -2,8 +2,10 @@ package com.avioconsulting.mule.opentelemetry.api.processor;
 
 import com.avioconsulting.mule.opentelemetry.internal.connection.TraceContextHandler;
 import com.avioconsulting.mule.opentelemetry.internal.processor.TraceComponent;
+import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
+import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.notification.EnrichedServerNotification;
 
 public interface ProcessorComponent {
@@ -20,6 +22,8 @@ public interface ProcessorComponent {
    * @return {@link TraceComponent}
    */
   TraceComponent getStartTraceComponent(EnrichedServerNotification notification);
+
+  TraceComponent getStartTraceComponent(Component component, Message message, String correlationId);
 
   /**
    * Build a {@link TraceComponent} for end of a flow-like container or a message

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryUtil.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryUtil.java
@@ -1,0 +1,37 @@
+package com.avioconsulting.mule.opentelemetry.internal;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class OpenTelemetryUtil {
+
+  /**
+   * <pre>
+   * Extract any attributes defined via system properties (see {@link System#getProperties()}) for provided <code>configName</code>.
+   *
+   * It uses `{configName}.otel.{attributeKey}` pattern to identify relevant system properties. Key matching is case-insensitive.
+   * </pre>
+   *
+   * @param configName
+   *            {@link String} name of the component's global configuration
+   *            element
+   * @param tags
+   *            Modifiable {@link Map} to populate any
+   * @param sourceMap
+   *            {@link Map} contains all properties to search in
+   *
+   */
+  public static void addGlobalConfigSystemAttributes(String configName, Map<String, String> tags,
+      Map<String, String> sourceMap) {
+    if (configName == null || configName.trim().isEmpty())
+      return;
+    Objects.requireNonNull(tags, "Tags map cannot be null");
+    String configRef = configName.toLowerCase();
+    String replaceVal = configRef + ".otel.";
+    sourceMap.entrySet().stream().filter(e -> e.getKey().startsWith(configRef)).forEach(entry -> {
+      String propKey = entry.getKey().substring(replaceVal.length());
+      tags.put(propKey, entry.getValue());
+    });
+  }
+
+}

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptor.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptor.java
@@ -80,7 +80,7 @@ public class ProcessorTracingInterceptor implements ProcessorInterceptor {
           return;
         }
         traceComponent.ifPresent(tc -> {
-          LOGGER.info("Creating Span in the interceptor for {} at {}",
+          LOGGER.trace("Creating Span in the interceptor for {} at {}",
               location.getComponentIdentifier().getIdentifier(), location.getLocation());
           openTelemetryConnection.addProcessorSpan(tc, location.getRootContainerName());
           String transactionId = openTelemetryConnection.getTransactionStore().transactionIdFor(event);

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AbstractProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AbstractProcessorComponent.java
@@ -69,12 +69,11 @@ public abstract class AbstractProcessorComponent implements ProcessorComponent {
 
   @Override
   public TraceComponent getEndTraceComponent(EnrichedServerNotification notification) {
-    return getTraceComponentBuilderFor(notification)
-        .build();
+    return getTraceComponentBuilderFor(notification);
   }
 
-  protected TraceComponent.Builder getTraceComponentBuilderFor(EnrichedServerNotification notification) {
-    return TraceComponent.newBuilder(notification.getResourceIdentifier())
+  protected TraceComponent getTraceComponentBuilderFor(EnrichedServerNotification notification) {
+    return TraceComponent.named(notification.getResourceIdentifier())
         .withTransactionId(getTransactionId(notification))
         .withLocation(notification.getComponent().getLocation().getLocation())
         .withTags(new HashMap<>())
@@ -82,9 +81,9 @@ public abstract class AbstractProcessorComponent implements ProcessorComponent {
             notification.getEvent().getError().map(Error::getDescription).orElse(null));
   }
 
-  protected TraceComponent.Builder getBaseTraceComponent(
+  protected TraceComponent getBaseTraceComponent(
       EnrichedServerNotification notification) {
-    return TraceComponent.newBuilder(notification.getComponent().getLocation().getLocation())
+    return TraceComponent.named(notification.getComponent().getLocation().getLocation())
         .withLocation(notification.getComponent().getLocation().getLocation())
         .withSpanName(notification.getComponent().getIdentifier().getName())
         .withTransactionId(getTransactionId(notification));
@@ -157,13 +156,12 @@ public abstract class AbstractProcessorComponent implements ProcessorComponent {
     tags.put(MULE_CORRELATION_ID.getKey(), correlationId);
     tags.putAll(getAttributes(component,
         message.getAttributes()));
-    return TraceComponent.newBuilder(component.getLocation().getLocation())
+    return TraceComponent.named(component.getLocation().getLocation())
         .withLocation(component.getLocation().getLocation())
         .withSpanName(getDefaultSpanName(tags))
         .withTags(tags)
         .withSpanKind(getSpanKind())
-        .withTransactionId(correlationId)
-        .build();
+        .withTransactionId(correlationId);
   }
 
   protected void addTagIfPresent(Map<String, String> sourceMap, String sourceKey, Map<String, String> targetMap,
@@ -173,9 +171,8 @@ public abstract class AbstractProcessorComponent implements ProcessorComponent {
   }
 
   protected Optional<Component> getSourceComponent(EnrichedServerNotification notification) {
-    Optional<Component> component = configurationComponentLocator.find(Location.builderFromStringRepresentation(
+    return configurationComponentLocator.find(Location.builderFromStringRepresentation(
         notification.getEvent().getContext().getOriginatingLocation().getLocation()).build());
-    return component;
   }
 
   protected enum ContextMapGetter implements TextMapGetter<Map<String, String>> {

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AnypointMQProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AnypointMQProcessorComponent.java
@@ -63,11 +63,10 @@ public class AnypointMQProcessorComponent extends AbstractProcessorComponent {
       // a different trace id than the one created by flow containing Consume
       // operation.
       // Should we add the message span context to Span link?
-      startTraceComponent = startTraceComponent.toBuilder().withSpanKind(SpanKind.CONSUMER)
+      startTraceComponent = startTraceComponent.withSpanKind(SpanKind.CONSUMER)
           .withSpanName(
               formattedSpanName(startTraceComponent.getTags().get(MESSAGING_DESTINATION_NAME.getKey()),
-                  RECEIVE))
-          .build();
+                  RECEIVE));
     }
     return startTraceComponent;
   }
@@ -117,25 +116,24 @@ public class AnypointMQProcessorComponent extends AbstractProcessorComponent {
     Map<String, String> tags = getAttributes(getSourceComponent(notification).orElse(notification.getComponent()),
         attributesTypedValue);
     tags.put(MESSAGING_OPERATION.getKey(), PROCESS);
-    TraceComponent traceComponent = TraceComponent.newBuilder(notification.getResourceIdentifier())
+    return TraceComponent.named(notification.getResourceIdentifier())
         .withTags(tags)
         .withTransactionId(getTransactionId(notification))
         .withSpanName(formattedSpanName(attributes.getDestination(), PROCESS))
         .withStatsCode(StatusCode.OK)
         .withSpanKind(SpanKind.CONSUMER)
-        .withContext(traceContextHandler.getTraceContext(attributes.getProperties(), ContextMapGetter.INSTANCE))
-        .build();
-    return traceComponent;
+        .withContext(
+            traceContextHandler.getTraceContext(attributes.getProperties(), ContextMapGetter.INSTANCE));
   }
 
   @Override
   public TraceComponent getEndTraceComponent(EnrichedServerNotification notification) {
-    return getTraceComponentBuilderFor(notification).withStatsCode(StatusCode.OK).build();
+    return getTraceComponentBuilderFor(notification).withStatsCode(StatusCode.OK);
   }
 
   @Override
   public TraceComponent getSourceEndTraceComponent(EnrichedServerNotification notification,
       TraceContextHandler traceContextHandler) {
-    return getTraceComponentBuilderFor(notification).withStatsCode(StatusCode.OK).build();
+    return getTraceComponentBuilderFor(notification).withStatsCode(StatusCode.OK);
   }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AnypointMQProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/AnypointMQProcessorComponent.java
@@ -5,6 +5,7 @@ import com.mulesoft.extension.mq.api.attributes.AnypointMQMessageAttributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import org.mule.runtime.api.component.Component;
+import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.notification.EnrichedServerNotification;
 
@@ -53,8 +54,8 @@ public class AnypointMQProcessorComponent extends AbstractProcessorComponent {
   }
 
   @Override
-  public TraceComponent getStartTraceComponent(EnrichedServerNotification notification) {
-    TraceComponent startTraceComponent = super.getStartTraceComponent(notification);
+  public TraceComponent getStartTraceComponent(Component component, Message message, String correlationId) {
+    TraceComponent startTraceComponent = super.getStartTraceComponent(component, message, correlationId);
     if ("consume".equalsIgnoreCase(startTraceComponent.getTags().get(MULE_APP_PROCESSOR_NAME.getKey()))) {
       // TODO: Handling a different Parent Span than flow containing Consume
       // It may be possible that message was published by a different server flow

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponent.java
@@ -117,17 +117,17 @@ public class HttpProcessorComponent extends AbstractProcessorComponent {
   }
 
   @Override
-  public TraceComponent getStartTraceComponent(EnrichedServerNotification notification) {
+  public TraceComponent getStartTraceComponent(Component component, Message message, String correlationId) {
 
-    TraceComponent traceComponent = super.getStartTraceComponent(notification);
+    TraceComponent traceComponent = super.getStartTraceComponent(component, message, correlationId);
 
-    Map<String, String> requesterTags = getAttributes(notification.getInfo().getComponent(),
-        notification.getEvent().getMessage().getAttributes());
+    Map<String, String> requesterTags = getAttributes(component,
+        message.getAttributes());
     requesterTags.putAll(traceComponent.getTags());
 
-    return TraceComponent.newBuilder(notification.getResourceIdentifier())
+    return TraceComponent.newBuilder(component.getLocation().getRootContainerName())
         .withTags(requesterTags)
-        .withLocation(notification.getComponent().getLocation().getLocation())
+        .withLocation(component.getLocation().getLocation())
         .withSpanName(requesterTags.get(HTTP_ROUTE.getKey()))
         .withTransactionId(traceComponent.getTransactionId())
         .withSpanKind(getSpanKind())

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/TraceComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/TraceComponent.java
@@ -3,6 +3,8 @@ package com.avioconsulting.mule.opentelemetry.internal.processor;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
+
+import java.time.Instant;
 import java.util.Map;
 
 public class TraceComponent {
@@ -15,6 +17,9 @@ public class TraceComponent {
   private SpanKind spanKind = SpanKind.INTERNAL;
   private String errorMessage;
   private StatusCode statusCode = StatusCode.UNSET;
+  private Instant startTime;
+
+  private Instant endTime;
 
   private TraceComponent(Builder builder) {
     tags = builder.tags;
@@ -62,6 +67,24 @@ public class TraceComponent {
 
   public String getErrorMessage() {
     return errorMessage;
+  }
+
+  public Instant getStartTime() {
+    return startTime;
+  }
+
+  public Instant getEndTime() {
+    return this.endTime;
+  }
+
+  public TraceComponent withStartTime(Instant startTime) {
+    this.startTime = startTime;
+    return this;
+  }
+
+  public TraceComponent withEndTime(Instant endTime) {
+    this.endTime = endTime;
+    return this;
   }
 
   public Builder toBuilder() {

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/TraceComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/TraceComponent.java
@@ -14,27 +14,18 @@ public class TraceComponent {
   private String spanName;
   private String location;
   private Context context;
-  private SpanKind spanKind = SpanKind.INTERNAL;
+  private SpanKind spanKind;
   private String errorMessage;
-  private StatusCode statusCode = StatusCode.UNSET;
+  private StatusCode statusCode;
   private Instant startTime;
-
   private Instant endTime;
 
-  private TraceComponent(Builder builder) {
-    tags = builder.tags;
-    name = builder.name;
-    transactionId = builder.transactionId;
-    spanName = builder.spanName;
-    location = builder.location;
-    context = builder.context;
-    spanKind = builder.spanKind;
-    errorMessage = builder.errorMessage;
-    statusCode = builder.statusCode;
+  private TraceComponent(String name) {
+    this.name = name;
   }
 
-  public static Builder newBuilder(String name) {
-    return new Builder(name);
+  public static TraceComponent named(String name) {
+    return new TraceComponent(name);
   }
 
   public SpanKind getSpanKind() {
@@ -77,6 +68,46 @@ public class TraceComponent {
     return this.endTime;
   }
 
+  public TraceComponent withTags(Map<String, String> val) {
+    tags = val;
+    return this;
+  }
+
+  public TraceComponent withTransactionId(String val) {
+    transactionId = val;
+    return this;
+  }
+
+  public TraceComponent withSpanName(String val) {
+    spanName = val;
+    return this;
+  }
+
+  public TraceComponent withLocation(String val) {
+    location = val;
+    return this;
+  }
+
+  public TraceComponent withContext(Context val) {
+    context = val;
+    return this;
+  }
+
+  public TraceComponent withSpanKind(SpanKind val) {
+    spanKind = val;
+    return this;
+  }
+
+  public TraceComponent withErrorMessage(String val) {
+    errorMessage = val;
+    return this;
+  }
+
+  public TraceComponent withStatsCode(StatusCode statusCode) {
+    this.statusCode = statusCode;
+    return this;
+  }
+
   public TraceComponent withStartTime(Instant startTime) {
     this.startTime = startTime;
     return this;
@@ -87,79 +118,8 @@ public class TraceComponent {
     return this;
   }
 
-  public Builder toBuilder() {
-    return new Builder(this.getName())
-        .withErrorMessage(this.getErrorMessage())
-        .withContext(this.getContext())
-        .withTransactionId(this.getTransactionId())
-        .withTags(this.getTags())
-        .withSpanName(this.getSpanName())
-        .withLocation(this.getLocation())
-        .withSpanKind(this.getSpanKind())
-        .withStatsCode(this.getStatusCode());
-  }
-
   public StatusCode getStatusCode() {
     return statusCode;
   }
 
-  public static final class Builder {
-    public StatusCode statusCode;
-    private Map<String, String> tags;
-    private final String name;
-    private String transactionId;
-    private String spanName;
-    private String location;
-    private Context context;
-    private SpanKind spanKind;
-    private String errorMessage;
-
-    private Builder(String name) {
-      this.name = name;
-    }
-
-    public Builder withTags(Map<String, String> val) {
-      tags = val;
-      return this;
-    }
-
-    public Builder withTransactionId(String val) {
-      transactionId = val;
-      return this;
-    }
-
-    public Builder withSpanName(String val) {
-      spanName = val;
-      return this;
-    }
-
-    public Builder withLocation(String val) {
-      location = val;
-      return this;
-    }
-
-    public Builder withContext(Context val) {
-      context = val;
-      return this;
-    }
-
-    public Builder withSpanKind(SpanKind val) {
-      spanKind = val;
-      return this;
-    }
-
-    public Builder withErrorMessage(String val) {
-      errorMessage = val;
-      return this;
-    }
-
-    public Builder withStatsCode(StatusCode statusCode) {
-      this.statusCode = statusCode;
-      return this;
-    }
-
-    public TraceComponent build() {
-      return new TraceComponent(this);
-    }
-  }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
@@ -130,22 +130,23 @@ public class InMemoryTransactionStore implements TransactionStore {
   @Override
   public void addProcessorSpan(String transactionId, String containerName, String location, SpanBuilder spanBuilder) {
     Transaction transaction = getTransaction(transactionId);
-
-    if (transaction != null) {
-      LOGGER.trace(
-          "Adding Processor span to transaction {} for location '{}'",
-          transactionId,
-          location);
-      Span span = transaction
-          .getRootFlowSpan()
-          .addProcessorSpan(containerName, location, spanBuilder);
-      LOGGER.trace(
-          "Adding Processor span to transaction {} for locator span '{}': OT SpanId {}, TraceId {}",
-          transactionId,
-          location,
-          span.getSpanContext().getSpanId(),
-          span.getSpanContext().getTraceId());
+    if (transaction == null) {
+      return;
     }
+    LOGGER.trace(
+        "Adding Processor span to transaction {} for location '{}'",
+        transactionId,
+        location);
+    Span span = transaction
+        .getRootFlowSpan()
+        .addProcessorSpan(containerName, location, spanBuilder);
+    LOGGER.trace(
+        "Adding Processor span to transaction {} for locator span '{}': OT SpanId {}, TraceId {}",
+        transactionId,
+        location,
+        span.getSpanContext().getSpanId(),
+        span.getSpanContext().getTraceId());
+
   }
 
   @Override

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
@@ -1,5 +1,6 @@
 package com.avioconsulting.mule.opentelemetry;
 
+import com.avioconsulting.mule.opentelemetry.internal.connection.OpenTelemetryConnection;
 import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.DelegatedLoggingSpanExporterProvider;
 import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.DelegatedLoggingSpanExporterProvider.DelegatedLoggingSpanExporter;
 import com.avioconsulting.mule.opentelemetry.test.util.TestLoggerHandler;
@@ -32,7 +33,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ArtifactClassLoaderRunnerConfig(exportPluginClasses = {
+@ArtifactClassLoaderRunnerConfig(exportPluginClasses = { OpenTelemetryConnection.class,
     DelegatedLoggingSpanExporterProvider.class }, applicationSharedRuntimeLibs = {
         "org.apache.derby:derby" })
 public abstract class AbstractMuleArtifactTraceTest extends MuleArtifactFunctionalTestCase {
@@ -64,6 +65,7 @@ public abstract class AbstractMuleArtifactTraceTest extends MuleArtifactFunction
 
   @Override
   protected void doSetUpBeforeMuleContextCreation() throws Exception {
+    OpenTelemetryConnection.resetForTest();
     super.doSetUpBeforeMuleContextCreation();
     System.setProperty(TEST_TIMEOUT_SYSTEM_PROPERTY, "120_000_000");
   }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/MessageProcessorTracingInterceptorFactoryTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/MessageProcessorTracingInterceptorFactoryTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.TypedComponentIdentifier;
 import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.component.location.LocationPart;
 
 import java.util.Arrays;
@@ -30,6 +31,9 @@ public class MessageProcessorTracingInterceptorFactoryTest {
   @Mock
   MuleNotificationProcessor muleNotificationProcessor;
 
+  @Mock
+  ConfigurationComponentLocator configurationComponentLocator;
+
   @Before
   public void setMocks() {
     when(muleNotificationProcessor.hasConnection()).thenReturn(true);
@@ -37,8 +41,10 @@ public class MessageProcessorTracingInterceptorFactoryTest {
 
   @Test
   public void get() {
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor).get())
-        .isInstanceOf(ProcessorTracingInterceptor.class);
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
+            .get())
+                .isInstanceOf(ProcessorTracingInterceptor.class);
   }
 
   @Test
@@ -59,8 +65,10 @@ public class MessageProcessorTracingInterceptorFactoryTest {
     when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
     when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
     when(location.getParts()).thenReturn(Arrays.asList(part1));
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor).intercept(location))
-        .isFalse();
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
+            .intercept(location))
+                .isFalse();
   }
 
   private TypedComponentIdentifier getComponentIdentifier(String namespace, String name) {
@@ -89,8 +97,10 @@ public class MessageProcessorTracingInterceptorFactoryTest {
     when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
     when(location.getParts()).thenReturn(Arrays.asList(part1));
 
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor).intercept(location))
-        .isTrue();
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
+            .intercept(location))
+                .isTrue();
   }
 
   @Test
@@ -108,8 +118,10 @@ public class MessageProcessorTracingInterceptorFactoryTest {
     when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
     when(location.getParts()).thenReturn(Arrays.asList(part1));
 
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor).intercept(location))
-        .isTrue();
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
+            .intercept(location))
+                .isTrue();
   }
 
   @Test
@@ -127,8 +139,10 @@ public class MessageProcessorTracingInterceptorFactoryTest {
     when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
     when(location.getParts()).thenReturn(Arrays.asList(part1));
 
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor).intercept(location))
-        .isFalse();
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
+            .intercept(location))
+                .isFalse();
   }
 
   @Test
@@ -150,8 +164,10 @@ public class MessageProcessorTracingInterceptorFactoryTest {
     muleNotificationProcessor1.init(() -> null, new TraceLevelConfiguration(true, Collections.emptyList(),
         Collections.singletonList(new MuleComponent("http", "*")), Collections.emptyList()));
 
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor1).intercept(location))
-        .isFalse();
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor1, configurationComponentLocator)
+            .intercept(location))
+                .isFalse();
   }
 
   @Test
@@ -168,8 +184,10 @@ public class MessageProcessorTracingInterceptorFactoryTest {
 
     TypedComponentIdentifier componentIdentifier = getComponentIdentifier(null, null);
     when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor).intercept(location))
-        .isTrue();
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
+            .intercept(location))
+                .isTrue();
   }
 
   private static LocationPart getLocationPart(String path) {
@@ -183,8 +201,10 @@ public class MessageProcessorTracingInterceptorFactoryTest {
     reset(muleNotificationProcessor);
     when(muleNotificationProcessor.hasConnection()).thenReturn(false);
     ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor).intercept(location))
-        .isFalse();
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
+            .intercept(location))
+                .isFalse();
   }
 
   @Test
@@ -199,14 +219,18 @@ public class MessageProcessorTracingInterceptorFactoryTest {
     when(location.getParts()).thenReturn(Arrays.asList(part1));
     TypedComponentIdentifier componentIdentifier = getComponentIdentifier(null, null);
     when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor).intercept(location))
-        .as("Interception before system property")
-        .isTrue();
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
+            .intercept(location))
+                .as("Interception before system property")
+                .isTrue();
     System.setProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME, "false");
 
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor).intercept(location))
-        .as("Interception after system property")
-        .isFalse();
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
+            .intercept(location))
+                .as("Interception after system property")
+                .isFalse();
     System.clearProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME);
   }
 
@@ -216,11 +240,12 @@ public class MessageProcessorTracingInterceptorFactoryTest {
         "ee,mule,validations,aggregators,json,oauth,scripting,tracing,oauth2-provider,xml,wss,spring,java,avio-logger"
             .split(","))
         .map(s -> new MuleComponent(s, "*")).collect(Collectors.toList());
-    assertThat(new MessageProcessorTracingInterceptorFactory(new MuleNotificationProcessor(null))
-        .getInterceptExclusions())
-            .as("Default Exclusions")
-            .isNotEmpty()
-            .containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(new MessageProcessorTracingInterceptorFactory(new MuleNotificationProcessor(null),
+        configurationComponentLocator)
+            .getInterceptExclusions())
+                .as("Default Exclusions")
+                .isNotEmpty()
+                .containsExactlyInAnyOrderElementsOf(expected);
   }
 
   @Test
@@ -234,20 +259,23 @@ public class MessageProcessorTracingInterceptorFactoryTest {
     MuleNotificationProcessor muleNotificationProcessor1 = new MuleNotificationProcessor(null);
     muleNotificationProcessor1.init(null, new TraceLevelConfiguration(true, Collections.emptyList(),
         Collections.singletonList(new MuleComponent("mule", "logger")), Collections.emptyList()));
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor1).getInterceptExclusions())
-        .as("Default with Trace level Exclusions")
-        .isNotEmpty()
-        .containsAll(expected)
-        .contains(new MuleComponent("mule", "logger"));
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor1, configurationComponentLocator)
+            .getInterceptExclusions())
+                .as("Default with Trace level Exclusions")
+                .isNotEmpty()
+                .containsAll(expected)
+                .contains(new MuleComponent("mule", "logger"));
   }
 
   @Test
   public void getInterceptInclusions() {
-    assertThat(new MessageProcessorTracingInterceptorFactory(new MuleNotificationProcessor(null))
-        .getInterceptInclusions())
-            .as("Default Inclusion")
-            .isNotEmpty()
-            .containsOnly(new MuleComponent("mule", "flow-ref"));
+    assertThat(new MessageProcessorTracingInterceptorFactory(new MuleNotificationProcessor(null),
+        configurationComponentLocator)
+            .getInterceptInclusions())
+                .as("Default Inclusion")
+                .isNotEmpty()
+                .containsOnly(new MuleComponent("mule", "flow-ref"));
   }
 
   @Test
@@ -255,10 +283,12 @@ public class MessageProcessorTracingInterceptorFactoryTest {
     MuleNotificationProcessor muleNotificationProcessor1 = new MuleNotificationProcessor(null);
     muleNotificationProcessor1.init(null, new TraceLevelConfiguration(true, Collections.emptyList(),
         Collections.emptyList(), Collections.singletonList(new MuleComponent("mule", "logger"))));
-    assertThat(new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor1).getInterceptInclusions())
-        .as("Default with Trace level Inclusion")
-        .isNotEmpty()
-        .containsOnly(new MuleComponent("mule", "flow-ref"),
-            new MuleComponent("mule", "logger"));
+    assertThat(
+        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor1, configurationComponentLocator)
+            .getInterceptInclusions())
+                .as("Default with Trace level Inclusion")
+                .isNotEmpty()
+                .containsOnly(new MuleComponent("mule", "flow-ref"),
+                    new MuleComponent("mule", "logger"));
   }
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptorTest.java
@@ -4,7 +4,10 @@ import com.avioconsulting.mule.opentelemetry.internal.connection.OpenTelemetryCo
 import com.avioconsulting.mule.opentelemetry.internal.processor.MuleNotificationProcessor;
 import com.avioconsulting.mule.opentelemetry.internal.store.TransactionStore;
 import org.junit.Test;
+import org.mule.runtime.api.component.ComponentIdentifier;
+import org.mule.runtime.api.component.TypedComponentIdentifier;
 import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.interception.InterceptionAction;
 import org.mule.runtime.api.interception.InterceptionEvent;
 
@@ -18,7 +21,7 @@ import static org.mockito.Mockito.*;
 public class ProcessorTracingInterceptorTest {
 
   @Test
-  public void injectContextInVars() {
+  public void injectContextInVars_NonProcessorComponent() {
     OpenTelemetryConnection connection = mock(OpenTelemetryConnection.class);
     TransactionStore transactionStore = mock(TransactionStore.class);
     when(connection.getTransactionStore()).thenReturn(transactionStore);
@@ -27,11 +30,17 @@ public class ProcessorTracingInterceptorTest {
     ComponentLocation location = mock(ComponentLocation.class);
     when(location.getLocation()).thenReturn("test-location");
     when(location.getRootContainerName()).thenReturn("test-flow-name");
-    when(connection.getTraceContext("random-id", location))
+    ComponentIdentifier ci = mock(ComponentIdentifier.class);
+    TypedComponentIdentifier tci = mock(TypedComponentIdentifier.class);
+    when(tci.getIdentifier()).thenReturn(ci);
+    when(location.getComponentIdentifier()).thenReturn(tci);
+    when(connection.getTraceContext("random-id"))
         .thenReturn(traceparentMap);
     MuleNotificationProcessor muleNotificationProcessor = mock(MuleNotificationProcessor.class);
     when(muleNotificationProcessor.getConnectionSupplier()).thenReturn(() -> connection);
-    ProcessorTracingInterceptor interceptor = new ProcessorTracingInterceptor(muleNotificationProcessor);
+    ConfigurationComponentLocator configurationComponentLocator = mock(ConfigurationComponentLocator.class);
+    ProcessorTracingInterceptor interceptor = new ProcessorTracingInterceptor(muleNotificationProcessor,
+        configurationComponentLocator);
 
     InterceptionEvent interceptionEvent = mock(InterceptionEvent.class);
     interceptor.before(location, Collections.emptyMap(), interceptionEvent);
@@ -41,7 +50,9 @@ public class ProcessorTracingInterceptorTest {
   @Test
   public void aroundInterceptProceeds() {
     MuleNotificationProcessor muleNotificationProcessor = mock(MuleNotificationProcessor.class);
-    ProcessorTracingInterceptor interceptor = new ProcessorTracingInterceptor(muleNotificationProcessor);
+    ConfigurationComponentLocator configurationComponentLocator = mock(ConfigurationComponentLocator.class);
+    ProcessorTracingInterceptor interceptor = new ProcessorTracingInterceptor(muleNotificationProcessor,
+        configurationComponentLocator);
     ComponentLocation location = mock(ComponentLocation.class);
     when(location.getLocation()).thenReturn("test-location");
     InterceptionEvent interceptionEvent = mock(InterceptionEvent.class);

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/jmh/ProcessorTracingInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/jmh/ProcessorTracingInterceptorTest.java
@@ -54,10 +54,11 @@ public class ProcessorTracingInterceptorTest extends AbstractJMHTest {
 
     connection.getTransactionStore().addProcessorSpan(TEST_1_TRANSACTION_ID, TEST_1_FLOW, TEST_1_FLOW_FLOW_REF,
         tracer.spanBuilder(TEST_1_FLOW_FLOW_REF).setSpanKind(SpanKind.INTERNAL));
-    ConfigurationComponentLocator componentLocator = mock(ConfigurationComponentLocator.class);
-    MuleNotificationProcessor muleNotificationProcessor = new MuleNotificationProcessor(componentLocator);
+    ConfigurationComponentLocator configurationComponentLocator = mock(ConfigurationComponentLocator.class);
+    MuleNotificationProcessor muleNotificationProcessor = new MuleNotificationProcessor(
+        configurationComponentLocator);
     muleNotificationProcessor.init(() -> connection, true);
-    interceptor = new ProcessorTracingInterceptor(muleNotificationProcessor);
+    interceptor = new ProcessorTracingInterceptor(muleNotificationProcessor, configurationComponentLocator);
     event = new TestInterceptionEvent(TEST_1_TRANSACTION_ID);
   }
 


### PR DESCRIPTION
Notifications are processed asynchronously but processor interception is synchronous. For context injection, interceptors depend on spans. Notifications may not be processed before interception. This change moves span creation for intercepted components from notification to interceptor.

It also reduces the number of TraceComponent-related object creations by ~50% by removing the use of the builder. Previous profiling shows both objects for just 2 trace transactions in test app - 
<img width="633" alt="image" src="https://github.com/avioconsulting/mule-opentelemetry-module/assets/877286/f1b7f1d8-1059-44ef-84f3-4c1261a13ad7">
