### PR TITLE
fix: set span status for http spans on error

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
@@ -357,7 +357,7 @@ public class OpenTelemetryConnection implements TraceContextHandler {
   public void setSpanStatus(TraceComponent traceComponent, Span span) {
     if (traceComponent.getStatusCode() != null
         && !StatusCode.UNSET.equals(traceComponent.getStatusCode())) {
-      span.setStatus(traceComponent.getStatusCode());
+      span.setStatus(traceComponent.getStatusCode(), traceComponent.getErrorMessage());
     }
   }
 

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/test/DelegatedLoggingSpanTestExporter.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/test/DelegatedLoggingSpanTestExporter.java
@@ -30,6 +30,7 @@ public class DelegatedLoggingSpanTestExporter implements SpanExporter {
       span.setSpanKind(spanData.getKind().toString());
       span.setTraceId(spanData.getTraceId());
       span.setSpanStatus(spanData.getStatus().getStatusCode().name());
+      span.setSpanStatusDescription(spanData.getStatus().getDescription());
       span.setInstrumentationName(spanData.getInstrumentationScopeInfo().getName());
       span.setInstrumentationVersion(spanData.getInstrumentationScopeInfo().getVersion());
       Map<String, Object> attributes = new HashMap<>();
@@ -70,6 +71,7 @@ public class DelegatedLoggingSpanTestExporter implements SpanExporter {
 
     private SpanContext parentSpanContext;
     private SpanContext spanContext;
+    private String spanStatusDescription;
 
     public String getInstrumentationName() {
       return instrumentationName;
@@ -93,6 +95,15 @@ public class DelegatedLoggingSpanTestExporter implements SpanExporter {
 
     public void setSpanStatus(String spanStatus) {
       this.spanStatus = spanStatus;
+    }
+
+    public String getSpanStatusDescription() {
+      return spanStatusDescription;
+    }
+
+    public Span setSpanStatusDescription(String spanStatusDescription) {
+      this.spanStatusDescription = spanStatusDescription;
+      return this;
     }
 
     public void setSpanName(String spanName) {
@@ -161,6 +172,7 @@ public class DelegatedLoggingSpanTestExporter implements SpanExporter {
           ", spanId='" + spanId + '\'' +
           ", spanKind='" + spanKind + '\'' +
           ", spanStatus='" + spanStatus + '\'' +
+          ", spanStatusDescription='" + spanStatusDescription + '\'' +
           ", attributes=" + attributes +
           ", parentSpanContext=" + parentSpanContext +
           ", spanContext=" + spanContext +

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponent.java
@@ -81,6 +81,12 @@ public class HttpProcessorComponent extends AbstractProcessorComponent {
         .orElse(notification.getEvent().getMessage());
     TypedValue<HttpResponseAttributes> responseAttributes = responseMessage.getAttributes();
 
+    // Sometimes errors such as HTTP:CONNECTIVITY can cause failure before the HTTP
+    // is established
+    // in such cases error object will be there but not the HTTP Response attributes
+    notification.getEvent().getError()
+        .ifPresent(error -> endTraceComponent
+            .withStatsCode(getSpanStatus(false, 500)));
     if (responseAttributes.getValue() == null
         || !(responseAttributes.getValue() instanceof HttpResponseAttributes)) {
       // When HTTP Requester executes successfully (eg. 200), notification event DOES

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryHttpTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryHttpTest.java
@@ -183,8 +183,9 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .anySatisfy(span -> {
           assertThat(span)
               .as("Span for http:request")
-              .extracting("spanName", "spanKind", "traceId")
-              .containsOnly("/remote/invalid", "CLIENT", head.getTraceId());
+              .extracting("spanName", "spanKind", "traceId", "spanStatus", "spanStatusDescription")
+              .containsOnly("/remote/invalid", "CLIENT", head.getTraceId(), "ERROR",
+                  "HTTP GET on resource 'http://0.0.0.0:9080/remote/invalid' failed: Connection refused.");
         }));
 
   }


### PR DESCRIPTION
Closes #131 

<img width="1256" alt="image" src="https://github.com/avioconsulting/mule-opentelemetry-module/assets/877286/77e424ed-6b56-4b12-905f-7237fbd54ee8">


Since there is no HTTP status code received or sent for this HTTP Client call, there is none captured on the span itself but Span status has been marked as ERROR -
 
<img width="1273" alt="image" src="https://github.com/avioconsulting/mule-opentelemetry-module/assets/877286/54ed2026-95eb-4362-b3a7-e0f000f014d4">


Whenever HTTP status codes are received/sent, they are captured and ERRORed as expected -

<img width="1273" alt="image" src="https://github.com/avioconsulting/mule-opentelemetry-module/assets/877286/bf016d86-561a-4572-bf03-3ec919ab32e6">


