### PR TITLE
feat: rename http spans by apikit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,6 +473,21 @@
             <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.modules</groupId>
+            <artifactId>mule-apikit-module</artifactId>
+            <version>1.8.4</version>
+            <classifier>mule-plugin</classifier>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <!-- Adding apikit module without xml-apis causes
+            java.lang.NoClassDefFoundError: org/w3c/dom/ElementTraversal -->
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>1.4.01</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
@@ -3,7 +3,7 @@ package com.avioconsulting.mule.opentelemetry.internal.connection;
 import com.avioconsulting.mule.opentelemetry.api.config.metrics.CustomMetricInstrumentDefinition;
 import com.avioconsulting.mule.opentelemetry.internal.config.CustomMetricInstrumentHolder;
 import com.avioconsulting.mule.opentelemetry.api.config.metrics.MetricsInstrumentType;
-import com.avioconsulting.mule.opentelemetry.internal.OpenTelemetryUtil;
+import com.avioconsulting.mule.opentelemetry.internal.util.OpenTelemetryUtil;
 import com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryConfigWrapper;
 import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.metrics.MetricsInstaller;
 import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.SemanticAttributes;
@@ -12,6 +12,7 @@ import com.avioconsulting.mule.opentelemetry.internal.store.InMemoryTransactionS
 import com.avioconsulting.mule.opentelemetry.internal.store.SpanMeta;
 import com.avioconsulting.mule.opentelemetry.internal.store.TransactionMeta;
 import com.avioconsulting.mule.opentelemetry.internal.store.TransactionStore;
+import com.avioconsulting.mule.opentelemetry.internal.util.PropertiesUtil;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.events.GlobalEventEmitterProvider;
@@ -106,6 +107,7 @@ public class OpenTelemetryConnection implements TraceContextHandler {
         .build();
     setupCustomMetrics(openTelemetryConfigWrapper);
     transactionStore = InMemoryTransactionStore.getInstance();
+    PropertiesUtil.init();
   }
 
   private void setupCustomMetrics(OpenTelemetryConfigWrapper openTelemetryConfigWrapper) {

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/APIKitProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/APIKitProcessorComponent.java
@@ -1,0 +1,30 @@
+package com.avioconsulting.mule.opentelemetry.internal.processor;
+
+import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.SemanticAttributes;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class APIKitProcessorComponent extends AbstractProcessorComponent {
+  @Override
+  protected String getNamespace() {
+    return "apikit";
+  }
+
+  @Override
+  protected List<String> getOperations() {
+    return Collections.singletonList("router");
+  }
+
+  @Override
+  protected List<String> getSources() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected String getDefaultSpanName(Map<String, String> tags) {
+    return super.getDefaultSpanName(tags).concat(" ")
+        .concat(tags.get(SemanticAttributes.MULE_APP_PROCESSOR_CONFIG_REF.getKey()));
+  }
+}

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponent.java
@@ -1,6 +1,7 @@
 package com.avioconsulting.mule.opentelemetry.internal.processor;
 
 import com.avioconsulting.mule.opentelemetry.internal.connection.TraceContextHandler;
+import com.avioconsulting.mule.opentelemetry.internal.processor.util.HttpSpanUtil;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import org.mule.extension.http.api.HttpRequestAttributes;
@@ -179,7 +180,7 @@ public class HttpProcessorComponent extends AbstractProcessorComponent {
     return TraceComponent.named(notification.getResourceIdentifier())
         .withTags(tags)
         .withTransactionId(getTransactionId(notification))
-        .withSpanName(attributes.getListenerPath()) // In case of wildcard, it may be to generic. Eg. /api/*
+        .withSpanName(HttpSpanUtil.spanName(tags, attributes.getListenerPath()))
         .withContext(traceContextHandler.getTraceContext(attributes.getHeaders(), ContextMapGetter.INSTANCE));
   }
 

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/HttpSpanUtil.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/HttpSpanUtil.java
@@ -1,0 +1,76 @@
+package com.avioconsulting.mule.opentelemetry.internal.processor.util;
+
+import com.avioconsulting.mule.opentelemetry.internal.util.PropertiesUtil;
+import io.opentelemetry.semconv.SemanticAttributes;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.SemanticAttributes.MULE_APP_FLOW_NAME;
+
+public class HttpSpanUtil {
+
+  /**
+   * Get HTTP Method name with either old and new Semantic Attribute for Method.
+   * 
+   * @param tags
+   *            {@link Map} containing span tags
+   * @return String HTTP Method name
+   */
+  public static String method(Map<String, String> tags) {
+    String method = tags
+        .getOrDefault(SemanticAttributes.HTTP_METHOD.getKey(),
+            tags.get(SemanticAttributes.HTTP_REQUEST_METHOD.getKey()));
+    Objects.requireNonNull(method, "HTTP Method must not be null");
+    return method;
+  }
+
+  /**
+   * Generates HTTP Span name
+   * 
+   * @param tags
+   *            {@link Map} of Span tags with HTTP Method entry
+   * @param route
+   *            {@link String} HTTP Route path
+   * @return String span name
+   */
+  public static String spanName(Map<String, String> tags, String route) {
+    return spanName(method(tags), route);
+  }
+
+  /**
+   * Generates HTTP Span name
+   * 
+   * @param method
+   *            {@link String} HTTP Method name
+   * @param route
+   *            {@link String} HTTP Route path
+   * @return String span name
+   */
+  public static String spanName(String method, String route) {
+    if (!PropertiesUtil.isUseAPIKitSpanNames()) {
+      // Backward compatible to use old route naming without method names
+      return route;
+    }
+    return method.toUpperCase(Locale.ROOT) + " " + route;
+  }
+
+  /**
+   * Uses flow names to build a new span name
+   * 
+   * @param tags
+   *            {@link Map} containing span tags
+   * @param rootSpanName
+   *            {@link String}
+   * @return String name of the span using apikit route path
+   */
+  public static String apiKitRoutePath(Map<String, String> tags, String rootSpanName) {
+    Objects.requireNonNull(rootSpanName, "Root span name must not be null");
+    String flowName = tags.get(MULE_APP_FLOW_NAME.getKey());
+    String pathName = (flowName.split(":")[1]).replace(":", "")
+        .replaceAll("\\\\", "/")
+        .replaceAll("\\(", "{").replaceAll("\\)", "}");
+    return rootSpanName.replace("/*", pathName);
+  }
+}

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
@@ -55,7 +55,9 @@ public class InMemoryTransactionStore implements TransactionStore {
       transactionMap.put(
           transactionId,
           new Transaction(traceComponent.getTransactionId(), span.getSpanContext().getTraceId(), rootFlowName,
-              new FlowSpan(rootFlowName, span, transactionId).setTags(traceComponent.getTags()),
+              new FlowSpan(rootFlowName, span, transactionId)
+                  .setTags(traceComponent.getTags())
+                  .setRootSpanName(traceComponent.getSpanName()),
               traceComponent.getStartTime()));
     }
   }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/OpenTelemetryUtil.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/OpenTelemetryUtil.java
@@ -1,4 +1,4 @@
-package com.avioconsulting.mule.opentelemetry.internal;
+package com.avioconsulting.mule.opentelemetry.internal.util;
 
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/PropertiesUtil.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/PropertiesUtil.java
@@ -1,0 +1,45 @@
+package com.avioconsulting.mule.opentelemetry.internal.util;
+
+import java.util.Locale;
+
+public class PropertiesUtil {
+  public static final String MULE_OTEL_USE_APIKIT_SPAN_NAMES = "mule.otel.use.apikit.span.names";
+
+  /**
+   * Should APIKit Flow names be used to name http root spans? Default true.
+   */
+  private static boolean useAPIKitSpanNames = true;
+
+  private PropertiesUtil() {
+  }
+
+  static {
+    init();
+  }
+
+  public static void init() {
+    String useAPIKitSpanNames = getProperty(MULE_OTEL_USE_APIKIT_SPAN_NAMES);
+    if (useAPIKitSpanNames != null) {
+      PropertiesUtil.useAPIKitSpanNames = Boolean.parseBoolean(useAPIKitSpanNames);
+    }
+  }
+
+  public static String getProperty(String name) {
+    if (name == null)
+      return null;
+    String value = System.getProperty(name);
+    if (value == null) {
+      value = System.getenv(toEnvName(name));
+    }
+    return value;
+  }
+
+  private static String toEnvName(String propertyName) {
+    return propertyName.toUpperCase(Locale.ROOT).replaceAll("\\.", "_")
+        .replaceAll("-", "_");
+  }
+
+  public static boolean isUseAPIKitSpanNames() {
+    return useAPIKitSpanNames;
+  }
+}

--- a/src/main/resources/META-INF/services/com.avioconsulting.mule.opentelemetry.api.processor.ProcessorComponent
+++ b/src/main/resources/META-INF/services/com.avioconsulting.mule.opentelemetry.api.processor.ProcessorComponent
@@ -2,3 +2,4 @@ com.avioconsulting.mule.opentelemetry.internal.processor.HttpProcessorComponent
 com.avioconsulting.mule.opentelemetry.internal.processor.DBProcessorComponent
 com.avioconsulting.mule.opentelemetry.internal.processor.AnypointMQProcessorComponent
 com.avioconsulting.mule.opentelemetry.internal.processor.MuleCoreProcessorComponent
+com.avioconsulting.mule.opentelemetry.internal.processor.APIKitProcessorComponent

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/AbstractMuleArtifactTraceTest.java
@@ -6,8 +6,11 @@ import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.test.Del
 import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.test.DelegatedLoggingSpanTestExporterProvider;
 import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.test.DelegatedLoggingSpanTestExporter;
 import com.avioconsulting.mule.opentelemetry.test.util.TestLoggerHandler;
+import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -23,6 +26,7 @@ import org.mule.tck.probe.PollingProber;
 import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
@@ -127,6 +131,11 @@ public abstract class AbstractMuleArtifactTraceTest extends MuleArtifactFunction
     sendRequest(correlationId, path, expectedStatus, Collections.emptyMap());
   }
 
+  protected void sendRequest(String method, String correlationId, String path, int expectedStatus, HttpEntity body)
+      throws IOException, URISyntaxException {
+    sendRequest(method, correlationId, path, expectedStatus, Collections.emptyMap(), Collections.emptyMap(), body);
+  }
+
   protected void sendRequest(String correlationId, String path, int expectedStatus, Map<String, String> headers)
       throws IOException, URISyntaxException {
     sendRequest(correlationId, path, expectedStatus, headers, Collections.emptyMap());
@@ -135,18 +144,32 @@ public abstract class AbstractMuleArtifactTraceTest extends MuleArtifactFunction
   protected void sendRequest(String correlationId, String path, int expectedStatus, Map<String, String> headers,
       Map<String, String> queryParams)
       throws IOException, URISyntaxException {
-    HttpGet getRequest = new HttpGet();
+    sendRequest("get", correlationId, path, expectedStatus, headers, queryParams, null);
+  }
+
+  protected void sendRequest(String method, String correlationId, String path, int expectedStatus,
+      Map<String, String> headers,
+      Map<String, String> queryParams, HttpEntity body) throws URISyntaxException, IOException {
+    HttpUriRequest request;
     URIBuilder uriBuilder = new URIBuilder(String.format("http://localhost:%s/" + path, serverPort.getValue()));
     queryParams.forEach(uriBuilder::addParameter);
-    getRequest.setURI(uriBuilder.build());
-    getRequest.addHeader("X-CORRELATION-ID", correlationId);
-    headers.forEach(getRequest::addHeader);
+    URI uri = uriBuilder.build();
+    if ("post".equals(method)) {
+      request = new HttpPost(uri);
+      if (body != null)
+        ((HttpPost) request).setEntity(body);
+    } else {
+      request = new HttpGet(uri);
+    }
+    request.addHeader("X-CORRELATION-ID", correlationId);
+    headers.forEach(request::addHeader);
     try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-      try (CloseableHttpResponse response = httpClient.execute(getRequest)) {
+      try (CloseableHttpResponse response = httpClient.execute(request)) {
         if (expectedStatus != -1) {
           assertThat(response.getStatusLine().getStatusCode()).isEqualTo(expectedStatus);
         }
       }
     }
+
   }
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryAPIKitTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryAPIKitTest.java
@@ -1,0 +1,103 @@
+package com.avioconsulting.mule.opentelemetry;
+
+import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.test.DelegatedLoggingSpanTestExporter;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+
+public class MuleOpenTelemetryAPIKitTest extends AbstractMuleArtifactTraceTest {
+
+  @Override
+  protected String getConfigFile() {
+    return "apikit-order-exp.xml";
+  }
+
+  @Override
+  protected void doSetUpBeforeMuleContextCreation() throws Exception {
+    System.setProperty("mule.otel.http.root.span.route.path", "true");
+    super.doSetUpBeforeMuleContextCreation();
+  }
+
+  @Override
+  protected void doTearDownAfterMuleContextDispose() throws Exception {
+    System.clearProperty("mule.otel.http.root.span.route.path");
+    super.doTearDownAfterMuleContextDispose();
+  }
+
+  @Test
+  public void getAPIKitOrders() throws Exception {
+    sendRequest(CORRELATION_ID, "/api/orders/1234", 200);
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
+        .hasSize(3)
+        .anySatisfy(span -> {
+          assertThat(span)
+              .as("Span for http:listener source flow")
+              .extracting("spanName", "spanKind", "spanStatus")
+              .containsOnly("GET /api/orders/{orderId}", "SERVER", "UNSET");
+        }));
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
+        .anySatisfy(span -> {
+          assertThat(span)
+              .as("Span for http:listener apikit flow")
+              .extracting("spanName", "spanKind", "spanStatus")
+              .containsOnly("get:\\orders\\(orderId):order-exp-config", "SERVER", "UNSET");
+        }));
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
+        .anySatisfy(span -> {
+          assertThat(span)
+              .as("Span for apikit router component")
+              .extracting("spanName", "spanKind", "spanStatus")
+              .containsOnly("router:router order-exp-config", "INTERNAL", "UNSET");
+        }));
+  }
+
+  @Test
+  public void getAPIKitOrders_404Error() throws Exception {
+    sendRequest(CORRELATION_ID, "/api/something/1234", 404);
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
+        .hasSize(2)
+        .anySatisfy(span -> {
+          assertThat(span)
+              .as("Span for http:listener source flow")
+              .describedAs(
+                  "HTTP Source span not reaching to APIKit Flow and thus have the default HTTP Route path from listener as Span name")
+              .extracting("spanName", "spanKind", "spanStatus")
+              .containsOnly("GET /api/*", "SERVER", "UNSET");
+        }));
+  }
+
+  @Test
+  public void postAPIKitOrders() throws Exception {
+    StringEntity stringEntity = new StringEntity(
+        "{\"customerId\": \"d3988a7a-d36c-4483-b9d4-8fa5c3f46255\",\"orderItems\": " +
+            "[{\"productId\": 1,\"quantity\": 3}]," +
+            "\"shipmentAddressId\": \"4fb029b5-7b1b-4f26-b2b7-cd81879db669\"}",
+        ContentType.APPLICATION_JSON);
+    sendRequest("post", CORRELATION_ID, "/api/orders", 201, stringEntity);
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
+        .hasSize(3)
+        .anySatisfy(span -> {
+          assertThat(span)
+              .as("Span for http:listener source flow")
+              .extracting("spanName", "spanKind", "spanStatus")
+              .containsOnly("POST /api/orders", "SERVER", "UNSET");
+        }));
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
+        .anySatisfy(span -> {
+          assertThat(span)
+              .as("Span for http:listener apikit flow")
+              .extracting("spanName", "spanKind", "spanStatus")
+              .containsOnly("post:\\orders:application\\json:order-exp-config", "SERVER", "UNSET");
+        }));
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
+        .anySatisfy(span -> {
+          assertThat(span)
+              .as("Span for apikit router component")
+              .extracting("spanName", "spanKind", "spanStatus")
+              .containsOnly("router:router order-exp-config", "INTERNAL", "UNSET");
+        }));
+  }
+}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryHttpTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryHttpTest.java
@@ -22,7 +22,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .hasSize(1)
         .element(0)
         .extracting("spanName", "spanKind", "spanStatus")
-        .containsOnly("/test-wildcard/*", "SERVER", "UNSET"));
+        .containsOnly("GET /test-wildcard/*", "SERVER", "UNSET"));
     assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
         .element(0)
         .extracting("attributes", InstanceOfAssertFactories.map(String.class, String.class))
@@ -36,7 +36,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .hasSize(1)
         .element(0)
         .extracting("spanName", "spanKind", "spanStatus")
-        .containsOnly("/test-json-status", "SERVER", "UNSET"));
+        .containsOnly("GET /test-json-status", "SERVER", "UNSET"));
     assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
         .element(0)
         .extracting("attributes", InstanceOfAssertFactories.map(String.class, String.class))
@@ -50,7 +50,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .hasSize(1)
         .element(0)
         .extracting("spanName", "spanKind", "spanStatus")
-        .containsOnly("/test-bad-status", "SERVER", "UNSET"));
+        .containsOnly("GET /test-bad-status", "SERVER", "UNSET"));
     assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
         .element(0)
         .extracting("attributes", InstanceOfAssertFactories.map(String.class, String.class))
@@ -64,7 +64,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .hasSize(1)
         .element(0)
         .extracting("spanName", "spanKind", "spanStatus")
-        .containsOnly("/test", "SERVER", "UNSET"));
+        .containsOnly("GET /test", "SERVER", "UNSET"));
     assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
         .element(0)
         .extracting("attributes", InstanceOfAssertFactories.map(String.class, String.class))
@@ -97,7 +97,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .hasSize(1)
         .element(0)
         .extracting("spanName", "spanKind", "spanStatus")
-        .containsOnly("/test/error-status", "SERVER", "ERROR"));
+        .containsOnly("GET /test/error-status", "SERVER", "ERROR"));
     assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
         .element(0)
         .extracting("attributes", InstanceOfAssertFactories.map(String.class, String.class))
@@ -111,7 +111,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .hasSize(1)
         .element(0)
         .extracting("spanName", "spanKind", "spanStatus")
-        .containsOnly("/test/no-status", "SERVER", "UNSET"));
+        .containsOnly("GET /test/no-status", "SERVER", "UNSET"));
     assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
         .element(0)
         .extracting("attributes", InstanceOfAssertFactories.map(String.class, String.class))
@@ -131,7 +131,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
           assertThat(span)
               .as("Span for http:listener source flow")
               .extracting("spanName", "spanKind", "traceId")
-              .containsOnly("/test/propagation/source", "SERVER", head.getTraceId());
+              .containsOnly("GET /test/propagation/source", "SERVER", head.getTraceId());
         }));
     await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
         .anySatisfy(span -> {
@@ -145,16 +145,16 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
           assertThat(span)
               .as("Span for http:listener target flow")
               .extracting("spanName", "spanKind", "traceId")
-              .containsOnly("/test/propagation/target", "SERVER", head.getTraceId());
+              .containsOnly("GET /test/propagation/target", "SERVER", head.getTraceId());
         }));
     DelegatedLoggingSpanTestExporter.Span sourceServer = DelegatedLoggingSpanTestExporter.spanQueue.stream()
-        .filter(s -> s.getSpanKind().equals("SERVER") && s.getSpanName().equals("/test/propagation/source"))
+        .filter(s -> s.getSpanKind().equals("SERVER") && s.getSpanName().equals("GET /test/propagation/source"))
         .findFirst().get();
     DelegatedLoggingSpanTestExporter.Span client = DelegatedLoggingSpanTestExporter.spanQueue.stream()
         .filter(s -> s.getSpanKind().equals("CLIENT") && s.getSpanName().equals("/test/propagation/target"))
         .findFirst().get();
     DelegatedLoggingSpanTestExporter.Span targetServer = DelegatedLoggingSpanTestExporter.spanQueue.stream()
-        .filter(s -> s.getSpanKind().equals("SERVER") && s.getSpanName().equals("/test/propagation/target"))
+        .filter(s -> s.getSpanKind().equals("SERVER") && s.getSpanName().equals("GET /test/propagation/target"))
         .findFirst().get();
 
     assertThat(targetServer.getParentSpanContext())
@@ -177,7 +177,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
           assertThat(span)
               .as("Span for http:listener flow")
               .extracting("spanName", "spanKind", "traceId")
-              .containsOnly("/test-invalid-request", "SERVER", head.getTraceId());
+              .containsOnly("GET /test-invalid-request", "SERVER", head.getTraceId());
         }));
     await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
         .anySatisfy(span -> {
@@ -200,7 +200,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .filteredOnAssertions(span -> assertThat(span)
             .as("Span for http:listener flow")
             .extracting("spanName", "spanKind")
-            .containsOnly("/test-remote-request", "SERVER"))
+            .containsOnly("GET /test-remote-request", "SERVER"))
         .isNotEmpty()
         .hasSize(1)
         .element(0)
@@ -277,7 +277,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .filteredOnAssertions(span -> assertThat(span)
             .as("Span for http:listener flow")
             .extracting("spanName", "spanKind")
-            .containsOnly("/test-remote-request", "SERVER"))
+            .containsOnly("GET /test-remote-request", "SERVER"))
         .isNotEmpty()
         .hasSize(1)
         .element(0)
@@ -292,7 +292,7 @@ public class MuleOpenTelemetryHttpTest extends AbstractMuleArtifactTraceTest {
         .hasSize(1)
         .element(0).as("Span for http:listener flow")
         .extracting("spanName", "spanKind")
-        .containsOnly("/test/error/400", "SERVER"));
+        .containsOnly("GET /test/error/400", "SERVER"));
   }
 
   @Test

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsTest.java
@@ -27,7 +27,7 @@ public class MuleOpenTelemetryOperationsTest extends AbstractMuleArtifactTraceTe
         .hasSize(1)
         .element(0)
         .extracting("spanName", "spanKind", "spanStatus")
-        .containsOnly("/tags", "SERVER", "UNSET"));
+        .containsOnly("GET /tags", "SERVER", "UNSET"));
     assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
         .element(0)
         .extracting("attributes", InstanceOfAssertFactories.map(String.class, String.class))

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorEnabledTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorEnabledTest.java
@@ -29,7 +29,7 @@ public class MuleOpenTelemetryProcessorEnabledTest extends AbstractMuleArtifactT
             .containsOnly(tuple("logger:Logger", "INTERNAL"),
                 tuple("set-payload:Set Payload", "INTERNAL"),
                 tuple("logger:Logger", "INTERNAL"),
-                tuple("/test", "SERVER")));
+                tuple("GET /test", "SERVER")));
   }
 
   /**
@@ -48,7 +48,7 @@ public class MuleOpenTelemetryProcessorEnabledTest extends AbstractMuleArtifactT
             .hasSize(2)
             .extracting("spanName", "spanKind")
             .containsOnly(tuple("set-payload:Set Payload", "INTERNAL"),
-                tuple("/otel-processor-flow", "SERVER")));
+                tuple("GET /otel-processor-flow", "SERVER")));
   }
 
   @Test
@@ -67,9 +67,9 @@ public class MuleOpenTelemetryProcessorEnabledTest extends AbstractMuleArtifactT
               assertThat(span)
                   .as("Span for http:listener source flow")
                   .extracting("spanName", "spanKind", "traceId")
-                  .containsOnly("/test/remote/flow-ref", "SERVER", head.getTraceId());
+                  .containsOnly("GET /test/remote/flow-ref", "SERVER", head.getTraceId());
             }));
-    Span sourceServer = getSpan("SERVER", "/test/remote/flow-ref");
+    Span sourceServer = getSpan("SERVER", "GET /test/remote/flow-ref");
 
     Span flowRefTargetServer = getSpan("INTERNAL", "flow-ref:mule-opentelemetry-app-flow-ref-target");
     Span targetServer = getSpan("SERVER", "mule-opentelemetry-app-flow-ref-target");

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorPropertyOverrideTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryProcessorPropertyOverrideTest.java
@@ -36,7 +36,7 @@ public class MuleOpenTelemetryProcessorPropertyOverrideTest extends AbstractMule
             .as("Spans for listener and processors")
             .hasSize(1)
             .extracting("spanName", "spanKind")
-            .containsOnly(tuple("/test", "SERVER")));
+            .containsOnly(tuple("GET /test", "SERVER")));
   }
 
   /**
@@ -60,9 +60,9 @@ public class MuleOpenTelemetryProcessorPropertyOverrideTest extends AbstractMule
               assertThat(span)
                   .as("Span for http:listener source flow")
                   .extracting("spanName", "spanKind", "traceId")
-                  .containsOnly("/test/remote/flow-ref", "SERVER", head.getTraceId());
+                  .containsOnly("GET /test/remote/flow-ref", "SERVER", head.getTraceId());
             }));
-    DelegatedLoggingSpanTestExporter.Span sourceServer = getSpan("SERVER", "/test/remote/flow-ref");
+    DelegatedLoggingSpanTestExporter.Span sourceServer = getSpan("SERVER", "GET /test/remote/flow-ref");
 
     DelegatedLoggingSpanTestExporter.Span flowRefTargetServer = getSpan("INTERNAL",
         "flow-ref:mule-opentelemetry-app-flow-ref-target");

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponentTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponentTest.java
@@ -188,7 +188,7 @@ public class HttpProcessorComponentTest extends AbstractProcessorComponentTest {
 
     assertThat(sourceTraceComponent)
         .isNotNull()
-        .extracting("name", "spanName").containsExactly("test-flow", "/test");
+        .extracting("name", "spanName").containsExactly("test-flow", "GET /test");
     assertThat(sourceTraceComponent.getTags())
         .hasSize(7)
         .containsEntry("http.method", "GET")

--- a/src/test/resources/api/order-exp.raml
+++ b/src/test/resources/api/order-exp.raml
@@ -1,0 +1,30 @@
+#%RAML 1.0
+title: Order Experience API
+version: v1
+baseUri: /{version}
+
+types:
+  order: !include ./types/order.raml
+  orderSummary: !include ./types/orderSummary.raml
+
+/orders:
+  post:
+    description: Create New Order
+    body:
+      application/json:
+        type: order
+    responses:
+      201:
+        body:
+          application/json:
+            type: orderSummary
+  /{orderId}:
+    get:
+      description: Get Order Details
+      responses:
+        200:
+          body:
+            application/json:
+              type: order
+        404:
+    

--- a/src/test/resources/api/types/order.raml
+++ b/src/test/resources/api/types/order.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0 DataType
+displayName: Order
+properties:
+  customerId:
+    type: !include ./uuid.raml
+  orderItems:
+    type: array
+    items:
+      type: !include ./orderItem.raml
+    minItems: 1
+  shipmentAddressId:
+    type: !include ./uuid.raml
+

--- a/src/test/resources/api/types/orderItem.raml
+++ b/src/test/resources/api/types/orderItem.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0 DataType
+displayName: Order Item
+properties:
+  productId:
+    type: number
+    format: int
+    minimum: 1
+  quantity:
+    type: number
+    format: int
+    minimum: 1

--- a/src/test/resources/api/types/orderSummary.raml
+++ b/src/test/resources/api/types/orderSummary.raml
@@ -1,0 +1,6 @@
+#%RAML 1.0 DataType
+displayName: Order Summary
+properties:
+  orderId: 
+    type: !include uuid.raml
+  

--- a/src/test/resources/api/types/uuid.raml
+++ b/src/test/resources/api/types/uuid.raml
@@ -1,0 +1,5 @@
+#%RAML 1.0 DataType
+displayName: UUID v4
+type: string
+pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
+example: fa8e9930-54f2-4c63-ad47-0537913b395b

--- a/src/test/resources/apikit-order-exp.xml
+++ b/src/test/resources/apikit-order-exp.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:apikit="http://www.mulesoft.org/schema/mule/mule-apikit"
+      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+      http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+      http://www.mulesoft.org/schema/mule/mule-apikit http://www.mulesoft.org/schema/mule/mule-apikit/current/mule-apikit.xsd">
+    <apikit:config name="order-exp-config" api="order-exp.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" />
+    <import file="global-common.xml"/>
+    <flow name="order-exp-main">
+        <http:listener config-ref="HTTP_Listener_config" path="/api/*">
+            <http:response statusCode="#[vars.httpStatus default 200]">
+                <http:headers>#[vars.outboundHeaders default {}]</http:headers>
+            </http:response>
+            <http:error-response statusCode="#[vars.httpStatus default 500]">
+                <http:body>#[payload]</http:body>
+                <http:headers>#[vars.outboundHeaders default {}]</http:headers>
+            </http:error-response>
+        </http:listener>
+        <apikit:router config-ref="order-exp-config" />
+        <error-handler ref="global-apikit-error-handler"/>
+    </flow>
+    <flow name="get:\orders\(orderId):order-exp-config">
+        <set-variable value="#[attributes.uriParams.'orderId']" variableName="orderId" />
+        <logger level="INFO" message="get:\orders\(orderId):order-exp-config" />
+    </flow>
+    <flow name="post:\orders:application\json:order-exp-config">
+        <logger level="INFO" message="post:\orders:application\json:order-exp-config" />
+    </flow>
+</mule>

--- a/src/test/resources/global-common.xml
+++ b/src/test/resources/global-common.xml
@@ -31,5 +31,30 @@ http://www.mulesoft.org/schema/mule/opentelemetry http://www.mulesoft.org/schema
 	<http:request-config name="SELF_HTTP_Request_configuration" doc:name="HTTP Request configuration" doc:id="c18eed36-eb42-4c29-abc9-9e7a2c6049e1" >
 		<http:request-connection host="0.0.0.0" port="${http.port}" />
 	</http:request-config>
-
+	<error-handler name="global-apikit-error-handler">
+		<on-error-propagate type="APIKIT:BAD_REQUEST">
+			<set-payload value="#[output application/json --- {message: 'Bad request'}]"/>
+			<set-variable value="400" variableName="httpStatus" />
+		</on-error-propagate>
+		<on-error-propagate type="APIKIT:NOT_FOUND">
+			<set-payload value="#[output application/json --- {message: 'Resource not found'}]"/>
+			<set-variable value="404" variableName="httpStatus" />
+		</on-error-propagate>
+		<on-error-propagate type="APIKIT:METHOD_NOT_ALLOWED">
+			<set-payload value="#[output application/json --- {message: 'Method not allowed'}]"/>
+			<set-variable value="405" variableName="httpStatus" />
+		</on-error-propagate>
+		<on-error-propagate type="APIKIT:NOT_ACCEPTABLE">
+			<set-payload value="#[output application/json --- {message: 'Not acceptable'}]"/>
+			<set-variable value="406" variableName="httpStatus" />
+		</on-error-propagate>
+		<on-error-propagate type="APIKIT:UNSUPPORTED_MEDIA_TYPE">
+			<set-payload value="#[output application/json --- {message: 'Unsupported media type'}]"/>
+			<set-variable value="415" variableName="httpStatus" />
+		</on-error-propagate>
+		<on-error-propagate type="APIKIT:NOT_IMPLEMENTED">
+			<set-payload value="#[output application/json --- {message: 'Not Implemented'}]"/>
+			<set-variable value="501" variableName="httpStatus" />
+		</on-error-propagate>
+	</error-handler>
 </mule>


### PR DESCRIPTION
Closes #95 

The APIKit-based HTTP Span name updates after change - Gets Method name and then low-cardinality path as described in specification -
![image](https://github.com/avioconsulting/mule-opentelemetry-module/assets/877286/71b229b7-d3f4-40a4-9b2f-2edf9870b757)

As we are using APIKit Flows to rename traces, any requests that fail validation at APIKit Router level and do not reach APIKit flows will get consolidated under `{METHOD} /api/*`  bucket.

It will be possible to continue using the previous way with sys prop `mule.otel.use.apikit.span.names=false`  or env `MULE_OTEL_USE_APIKIT_SPAN_NAMES=false`  in case anyone wants that, otherwise now default will be to use this new naming.