### PR TITLE
fix: subflow context propagation

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/SemanticAttributes.java
@@ -126,4 +126,7 @@ public final class SemanticAttributes {
    * Key to capture Error types
    */
   public static final AttributeKey<String> ERROR_TYPE = AttributeKey.stringKey("error.type");
+
+  public static final AttributeKey<String> MULE_APP_SCOPE_SUBFLOW_NAME = AttributeKey
+      .stringKey("mule.app.scope.subflow.name");
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleCoreProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleCoreProcessorComponent.java
@@ -1,7 +1,14 @@
 package com.avioconsulting.mule.opentelemetry.internal.processor;
 
+import com.avioconsulting.mule.opentelemetry.internal.util.ComponentsUtil;
+import org.mule.runtime.api.component.Component;
+import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.api.notification.EnrichedServerNotification;
+
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This processor handles any specific operations or sources from Mule Core
@@ -24,5 +31,27 @@ public class MuleCoreProcessorComponent extends AbstractProcessorComponent {
   @Override
   protected List<String> getSources() {
     return Collections.emptyList();
+  }
+
+  @Override
+  protected <A> Map<String, String> getAttributes(Component component, TypedValue<A> attributes) {
+    Map<String, String> tags = new HashMap<>();
+    ComponentWrapper componentWrapper = new ComponentWrapper(component,
+        configurationComponentLocator);
+    if (ComponentsUtil.isFlowRef(component.getLocation())) {
+      tags.put("mule.app.processor.flowRef.name", componentWrapper.getParameter("name"));
+    }
+    return tags;
+  }
+
+  @Override
+  public TraceComponent getEndTraceComponent(EnrichedServerNotification notification) {
+    TraceComponent endTraceComponent = super.getEndTraceComponent(notification);
+    ComponentWrapper componentWrapper = new ComponentWrapper(notification.getComponent(),
+        configurationComponentLocator);
+    if (ComponentsUtil.isFlowRef(notification.getComponent().getLocation())) {
+      endTraceComponent.getTags().put("mule.app.processor.flowRef.name", componentWrapper.getParameter("name"));
+    }
+    return endTraceComponent;
   }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessor.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessor.java
@@ -9,6 +9,8 @@ import com.avioconsulting.mule.opentelemetry.internal.processor.metrics.MuleMetr
 import com.avioconsulting.mule.opentelemetry.internal.processor.service.ProcessorComponentService;
 import com.avioconsulting.mule.opentelemetry.internal.store.SpanMeta;
 import com.avioconsulting.mule.opentelemetry.internal.store.TransactionMeta;
+import com.avioconsulting.mule.opentelemetry.internal.util.ComponentsUtil;
+import io.opentelemetry.api.trace.SpanKind;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.notification.ExtensionNotification;
@@ -21,6 +23,11 @@ import javax.inject.Inject;
 import java.time.Instant;
 import java.util.*;
 import java.util.function.Supplier;
+
+import static com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.SemanticAttributes.MULE_APP_SCOPE_SUBFLOW_NAME;
+import static com.avioconsulting.mule.opentelemetry.internal.store.TransactionStore.TRACE_CONTEXT_MAP_KEY;
+import static com.avioconsulting.mule.opentelemetry.internal.util.ComponentsUtil.findLocation;
+import static com.avioconsulting.mule.opentelemetry.internal.util.ComponentsUtil.isFlowRef;
 
 /**
  * Notification Processor bean. This is injected through registry-bootstrap into
@@ -184,6 +191,32 @@ public class MuleNotificationProcessor {
             .withEndTime(Instant.ofEpochMilli(notification.getTimestamp()));
         SpanMeta spanMeta = openTelemetryConnection.endProcessorSpan(traceComponent,
             notification.getEvent().getError().orElse(null));
+
+        if (isFlowRef(notification.getComponent().getLocation())) {
+          findLocation(traceComponent.getTags().get("mule.app.processor.flowRef.name"),
+              configurationComponentLocator)
+                  .filter(ComponentsUtil::isSubFlow)
+                  .ifPresent(subFlowComp -> {
+                    TraceComponent subflowTrace = TraceComponent.named(subFlowComp.getLocation())
+                        .withTransactionId(traceComponent.getTransactionId())
+                        .withLocation(subFlowComp.getLocation())
+                        .withSpanName(subFlowComp.getLocation())
+                        .withSpanKind(SpanKind.INTERNAL)
+                        .withTags(Collections.singletonMap(MULE_APP_SCOPE_SUBFLOW_NAME.getKey(),
+                            subFlowComp.getLocation()))
+                        .withStatsCode(traceComponent.getStatusCode())
+                        .withEndTime(traceComponent.getEndTime())
+                        .withContext(traceComponent.getContext());
+                    SpanMeta subFlow = openTelemetryConnection.endProcessorSpan(subflowTrace,
+                        notification.getEvent().getError().orElse(null));
+                    if (subFlow != null) {
+                      muleMetricsProcessor.captureProcessorMetrics(notification.getComponent(),
+                          notification.getEvent().getError().orElse(null), location,
+                          spanMeta);
+                    }
+                  });
+        }
+
         if (spanMeta != null) {
           muleMetricsProcessor.captureProcessorMetrics(notification.getComponent(),
               notification.getEvent().getError().orElse(null), location, spanMeta);

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/ComponentsUtil.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/ComponentsUtil.java
@@ -1,0 +1,32 @@
+package com.avioconsulting.mule.opentelemetry.internal.util;
+
+import org.mule.runtime.api.component.Component;
+import org.mule.runtime.api.component.ComponentIdentifier;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
+
+import java.util.Optional;
+
+public class ComponentsUtil {
+
+  public static Optional<ComponentLocation> findLocation(String location,
+      ConfigurationComponentLocator configurationComponentLocator) {
+    return configurationComponentLocator.findAllLocations().stream().filter(cl -> cl.getLocation().equals(location))
+        .findFirst();
+  }
+
+  public static boolean isSubFlow(ComponentLocation location) {
+    return location.getComponentIdentifier().getIdentifier().getName().equals("sub-flow");
+  }
+
+  public static boolean isFlowRef(ComponentLocation location) {
+    return location.getComponentIdentifier().getIdentifier().getName().equals("flow-ref");
+  }
+
+  public static Optional<Component> findComponent(ComponentIdentifier identifier, String location,
+      ConfigurationComponentLocator configurationComponentLocator) {
+    return configurationComponentLocator
+        .find(identifier).stream()
+        .filter(c -> c.getLocation().getLocation().equals(location)).findFirst();
+  }
+}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryEnabledInterceptorHttpTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryEnabledInterceptorHttpTest.java
@@ -134,4 +134,56 @@ public class MuleOpenTelemetryEnabledInterceptorHttpTest extends AbstractMuleArt
         .containsOnly(mainFlow.getTraceId(), mainFlow.getSpanId());
 
   }
+
+  @Test
+  public void testInterceptorFlowRefPropagation() throws Exception {
+    CoreEvent event = flowRunner("intercept-subflow-flowref-context-propagation")
+        .withSourceCorrelationId("test-correlation-id").run();
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue).hasSize(6));
+    DelegatedLoggingSpanTestExporter.Span mainFlow = DelegatedLoggingSpanTestExporter.spanQueue.stream()
+        .filter(span -> span.getSpanName().equals("intercept-subflow-flowref-context-propagation")).findFirst()
+        .get();
+    DelegatedLoggingSpanTestExporter.Span beforeLogger = DelegatedLoggingSpanTestExporter.spanQueue.stream()
+        .filter(span -> span.getSpanName().equals("logger:before-flow-ref")).findFirst().get();
+    DelegatedLoggingSpanTestExporter.Span flowRef = DelegatedLoggingSpanTestExporter.spanQueue.stream()
+        .filter(span -> span.getSpanName().equals("flow-ref:flow-ref")).findFirst().get();
+    DelegatedLoggingSpanTestExporter.Span afterLogger = DelegatedLoggingSpanTestExporter.spanQueue.stream()
+        .filter(span -> span.getSpanName().equals("logger:after-flow-ref")).findFirst().get();
+    DelegatedLoggingSpanTestExporter.Span targetFlow = DelegatedLoggingSpanTestExporter.spanQueue.stream()
+        .filter(span -> span.getSpanName().equals("flow-ref-target-subflow")).findFirst().get();
+    DelegatedLoggingSpanTestExporter.Span targetLogger = DelegatedLoggingSpanTestExporter.spanQueue.stream()
+        .filter(span -> span.getSpanName().equals("logger:target-logger")).findFirst().get();
+
+    assertThat(beforeLogger.getParentSpanContext())
+        .as("Parent Span Context of a logger before flow-ref")
+        .describedAs("Parent span should be of main flow")
+        .extracting("traceId", "spanId")
+        .containsOnly(mainFlow.getTraceId(), mainFlow.getSpanId());
+
+    assertThat(flowRef.getParentSpanContext())
+        .as("Parent Span Context of a flow-ref in main flow")
+        .describedAs("Parent span should be of main flow")
+        .extracting("traceId", "spanId")
+        .containsOnly(mainFlow.getTraceId(), mainFlow.getSpanId());
+
+    assertThat(targetFlow.getParentSpanContext())
+        .as("Parent Span Context of a target flow invoked by flow-ref")
+        .describedAs("Parent span should be span of flow-ref")
+        .extracting("traceId", "spanId")
+        .containsOnly(mainFlow.getTraceId(), flowRef.getSpanId());
+
+    assertThat(targetLogger.getParentSpanContext())
+        .as("Parent Span Context of a target logger of target flow")
+        .describedAs("Parent span should be span of target flow")
+        .extracting("traceId", "spanId")
+        .containsOnly(mainFlow.getTraceId(), targetFlow.getSpanId());
+
+    assertThat(afterLogger.getParentSpanContext())
+        .as("Parent Span Context of a after logger in main flow")
+        .describedAs(
+            "Parent span should be span of main flow again since flow-ref's context variable will reset after flow-ref execution")
+        .extracting("traceId", "spanId")
+        .containsOnly(mainFlow.getTraceId(), mainFlow.getSpanId());
+
+  }
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptorTest.java
@@ -240,6 +240,7 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     when(location.getLocation()).thenReturn("test-location");
     when(location.getRootContainerName()).thenReturn("test-flow-name");
     ComponentIdentifier ci = mock(ComponentIdentifier.class);
+    when(ci.getName()).thenReturn("something");
     TypedComponentIdentifier tci = mock(TypedComponentIdentifier.class);
     when(tci.getIdentifier()).thenReturn(ci);
     when(location.getComponentIdentifier()).thenReturn(tci);

--- a/src/test/resources/mule-interceptor-tests.xml
+++ b/src/test/resources/mule-interceptor-tests.xml
@@ -53,4 +53,14 @@ http://www.mulesoft.org/schema/mule/opentelemetry http://www.mulesoft.org/schema
 	<flow name="flow-ref-target-flow">
 		<logger doc:name="target-logger" message="Target Logger"/>
 	</flow>
+
+	<flow name="intercept-subflow-flowref-context-propagation" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+		<logger doc:name="before-flow-ref" message="Before Flow ref"/>
+		<flow-ref name="flow-ref-target-subflow"/>
+		<logger doc:name="after-flow-ref" message="After Flow ref"/>
+	</flow>
+
+	<sub-flow name="flow-ref-target-subflow">
+		<logger doc:name="target-logger" message="Target Logger"/>
+	</sub-flow>
 </mule>


### PR DESCRIPTION
Creates a sub-flow span and propagates it to all processors in the sub-flow. Closes #141 

<img width="1045" alt="image" src="https://github.com/avioconsulting/mule-opentelemetry-module/assets/877286/e1e37208-5f67-4103-9754-107f92725061">
