### PR TITLE
feat: add long trace and span id to context

### DIFF
--- a/src/docs/asciidoc/module-config.adoc
+++ b/src/docs/asciidoc/module-config.adoc
@@ -389,10 +389,11 @@ NOTE: OpenTelemetry Trace Context is extracted/injected using configured Propaga
 
 To help with the context propagation, module allows to inject context into flow variables. This context includes following trace attributes -
 
-- TRACE_TRANSACTION_ID - An internal transaction id within Mule Context
-- traceId - Trace id of the current request
-- spanId - Span Id for the component used for creating context
-- OpenTelemetry Trace attributes such as traceparent, tracestate
+- *TRACE_TRANSACTION_ID* - An internal transaction id within Mule Context
+- *traceId* - Trace id of the current request
+- *traceIdLongLowPart* - Long value of the Trace Id Low part
+- *spanId* - Span Id for the component used for creating context
+- OpenTelemetry Trace attributes such as *traceparent*, *tracestate*
 
 Context can be injected in two ways, as described below.
 
@@ -525,8 +526,10 @@ Most commonly used attributes include -
 
 - Trace Id
 * Loggers can access the current trace id with `vars.OTEL_TRACE_CONTEXT.traceId`
+* Some APM backends (eg. DataDog) may require the Long trace Id instead of the 32-hex-character trace Id value. In that case, `vars.OTEL_TRACE_CONTEXT.traceIdLongLowPart` (since v1.6.0) can be used.
 - Span Id
 * Introduced with v1.5.0, Loggers can access the flow container span id with `vars.OTEL_TRACE_CONTEXT.spanId`
+* Some APM backends (eg. DataDog) may require the Long span Id instead of the 16-hex-character span Id value. In that case, `vars.OTEL_TRACE_CONTEXT.spanIdLong` (since v1.6.0) can be used.
 - Service name
 * Usually a static value, name of the application which can be injected through application properties such as `${domain}`
 - Deployment Environment

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
@@ -44,6 +44,8 @@ import static com.avioconsulting.mule.opentelemetry.internal.store.TransactionSt
 
 public class OpenTelemetryConnection implements TraceContextHandler {
 
+  public static final String TRACE_ID_LONG_LOW_PART = "traceIdLongLowPart";
+  public static final String SPAN_ID_LONG = "spanIdLong";
   private final Logger logger = LoggerFactory.getLogger(OpenTelemetryConnection.class);
 
   /**
@@ -253,8 +255,10 @@ public class OpenTelemetryConnection implements TraceContextHandler {
         componentLocation);
     Map<String, String> traceContext = new HashMap<>(10);
     traceContext.put(TRACE_TRANSACTION_ID, transactionId);
-    traceContext.put(TRACE_ID, getTransactionStore().getTraceIdForTransaction(transactionId));
+    traceContext.put(TRACE_ID, transactionContext.getTraceId());
+    traceContext.put(TRACE_ID_LONG_LOW_PART, transactionContext.getTraceIdLongLowPart());
     traceContext.put(SPAN_ID, transactionContext.getSpanId());
+    traceContext.put(SPAN_ID_LONG, transactionContext.getSpanIdLong());
     injectTraceContext(transactionContext.getContext(), traceContext,
         HashMapTextMapSetter.INSTANCE);
     logger.debug("Created trace context '{}' for TRACE_TRANSACTION_ID={}, Component Location '{}'", traceContext,

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/TransactionContext.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/TransactionContext.java
@@ -1,22 +1,63 @@
 package com.avioconsulting.mule.opentelemetry.internal.store;
 
+import com.avioconsulting.mule.opentelemetry.internal.util.EncodingUtil;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.context.Context;
 
 import java.util.Objects;
 
 public class TransactionContext {
-  private Context context;
-  private String spanId;
+  private Context context = Context.current();
+
+  /**
+   * Get the 16-hex-character lowercase string span id
+   */
+  private String spanId = SpanId.getInvalid();
+  /**
+   * Trace id is a 32-hex-character lowercase string built with two
+   * 16-hex-character lowercase strings,
+   * each representing a long value encoded to hex.
+   * First 16 characters represent High-long and the last 16 characters represent
+   * Low-long values making the trace id.
+   */
+  private String traceId = TraceId.getInvalid();
+
+  /**
+   * This method returns the String formatted Long value of span id. See
+   * {@link TransactionContext#getSpanId()}.
+   * Example: Span Id - "53f9aa133a283c1a"
+   * Long Low Id - "6051054573905787930"
+   */
+  private String spanIdLong = "0";
+
+  /**
+   * This method returns the String formatted Long value of the Low part of the
+   * trace id. See {@link TransactionContext#getTraceId()}.
+   * Example: Trace Id - fbc14552c62fbabc6a4bc6817cd983ce
+   * High-part - "fbc14552c62fbabc"
+   * Low-part - "6a4bc6817cd983ce"
+   * Long Low Id - "7659433850721371086"
+   */
+  private String traceIdLongLowPart = "0";
 
   public static TransactionContext of(Span span) {
-    return new TransactionContext()
+    TransactionContext transactionContext = new TransactionContext()
         .setContext(span.storeInContext(Context.current()))
-        .setSpanId(span.getSpanContext().getSpanId());
+        .setSpanId(span.getSpanContext().getSpanId())
+        .setTraceId(span.getSpanContext().getTraceId());
+    if (SpanId.isValid(transactionContext.getSpanId())) {
+      transactionContext.setSpanIdLong(EncodingUtil.longFromBase16Hex(transactionContext.getSpanId()));
+    }
+    if (TraceId.isValid(transactionContext.getTraceId())) {
+      transactionContext.setTraceIdLongLowPart(EncodingUtil.traceIdLong(transactionContext.getTraceId())[1]);
+    }
+    return transactionContext;
   }
 
   public static TransactionContext current() {
-    return new TransactionContext().setContext(Context.current());
+    return new TransactionContext();
   }
 
   public Context getContext() {
@@ -37,6 +78,33 @@ public class TransactionContext {
     return this;
   }
 
+  public String getTraceId() {
+    return traceId;
+  }
+
+  public TransactionContext setTraceId(String traceId) {
+    this.traceId = traceId;
+    return this;
+  }
+
+  public String getSpanIdLong() {
+    return spanIdLong;
+  }
+
+  public TransactionContext setSpanIdLong(String spanIdLong) {
+    this.spanIdLong = spanIdLong;
+    return this;
+  }
+
+  public String getTraceIdLongLowPart() {
+    return traceIdLongLowPart;
+  }
+
+  public TransactionContext setTraceIdLongLowPart(String traceIdLongLowPart) {
+    this.traceIdLongLowPart = traceIdLongLowPart;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o)
@@ -44,11 +112,14 @@ public class TransactionContext {
     if (o == null || getClass() != o.getClass())
       return false;
     TransactionContext that = (TransactionContext) o;
-    return Objects.equals(getContext(), that.getContext()) && Objects.equals(getSpanId(), that.getSpanId());
+    return Objects.equals(getContext(), that.getContext()) && Objects.equals(getSpanId(), that.getSpanId())
+        && Objects.equals(getTraceId(), that.getTraceId())
+        && Objects.equals(getSpanIdLong(), that.getSpanIdLong())
+        && Objects.equals(getTraceIdLongLowPart(), that.getTraceIdLongLowPart());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getContext(), getSpanId());
+    return Objects.hash(getContext(), getSpanId(), getTraceId(), getSpanIdLong(), getTraceIdLongLowPart());
   }
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/EncodingUtil.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/EncodingUtil.java
@@ -1,0 +1,17 @@
+package com.avioconsulting.mule.opentelemetry.internal.util;
+
+import static java.lang.Long.parseUnsignedLong;
+import static java.lang.Long.toUnsignedString;
+
+public class EncodingUtil {
+  public static String longFromBase16Hex(String inputHex) {
+    long longValue = parseUnsignedLong(inputHex, 16);
+    return toUnsignedString(longValue);
+  }
+
+  public static String[] traceIdLong(String inputHex) {
+    String hiLong = longFromBase16Hex(inputHex.substring(0, 16));
+    String lowLong = longFromBase16Hex(inputHex.substring(16));
+    return new String[] { hiLong, lowLong };
+  }
+}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsTest.java
@@ -49,6 +49,13 @@ public class MuleOpenTelemetryOperationsTest extends AbstractMuleArtifactTraceTe
         .getVariables().get("OTEL_CONTEXT");
     assertThat(otel_trace_context_from_interceptor.getValue())
         .containsExactlyEntriesOf(otel_context_from_operation.getValue());
+    assertThat(otel_trace_context_from_interceptor.getValue())
+        .containsKeys("traceId", "spanId", "spanIdLong", "traceIdLongLowPart", "TRACE_TRANSACTION_ID");
+    assertThat(otel_trace_context_from_interceptor.getValue())
+        .hasEntrySatisfying("spanIdLong", (value) -> assertThat(Long.parseUnsignedLong(value)).isNotEqualTo(0));
+    assertThat(otel_trace_context_from_interceptor.getValue())
+        .hasEntrySatisfying("traceIdLongLowPart",
+            (value) -> assertThat(Long.parseUnsignedLong(value)).isNotEqualTo(0));
   }
 
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/store/TransactionContextTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/store/TransactionContextTest.java
@@ -1,0 +1,46 @@
+package com.avioconsulting.mule.opentelemetry.internal.store;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransactionContextTest {
+
+  @Test
+  public void current() {
+    TransactionContext transactionContext = TransactionContext.current();
+    Assertions.assertThat(transactionContext)
+        .extracting("spanId", "spanIdLong", "traceId", "traceIdLongLowPart")
+        .containsOnly("0000000000000000", "0", "00000000000000000000000000000000", "0");
+    Assertions.assertThat(transactionContext.getContext())
+        .as("Current Context")
+        .isNotNull();
+  }
+
+  @Test
+  public void ofValidSpan() {
+    Span span = mock(Span.class);
+    SpanContext spanContext = mock(SpanContext.class);
+    when(spanContext.getSpanId()).thenReturn("53f9aa133a283c1a");
+    when(spanContext.getTraceId()).thenReturn("fbc14552c62fbabc6a4bc6817cd983ce");
+    when(span.getSpanContext()).thenReturn(spanContext);
+    when(span.storeInContext(any(Context.class))).thenReturn(Context.current());
+
+    TransactionContext transactionContext = TransactionContext.of(span);
+    Assertions.assertThat(transactionContext)
+        .extracting("spanId", "spanIdLong", "traceId", "traceIdLongLowPart")
+        .containsOnly("53f9aa133a283c1a", "6051054573905787930", "fbc14552c62fbabc6a4bc6817cd983ce",
+            "7659433850721371086");
+    Assertions.assertThat(transactionContext.getContext())
+        .as("Current Context")
+        .isNotNull();
+  }
+
+}


### PR DESCRIPTION
Adds two new entries in OTEL_TRACE_CONTEXT to aid in log correlation -

- traceIdLongLowPart - The Long value of the trace id low part
- spanIdLong - The Long value of the span id

Closes #144 