### PR TITLE
fix: router span relation

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleCoreProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleCoreProcessorComponent.java
@@ -12,6 +12,7 @@ import org.mule.runtime.api.notification.EnrichedServerNotification;
 import java.util.*;
 
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.ROUTER;
+import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.SCOPE;
 
 /**
  * This processor handles any specific operations or sources from Mule Core
@@ -21,8 +22,6 @@ import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentT
  */
 public class MuleCoreProcessorComponent extends AbstractProcessorComponent {
 
-  private List<ComponentType> scopes = Arrays.asList(ROUTER);
-
   @Override
   protected String getNamespace() {
     return NAMESPACE_MULE;
@@ -30,7 +29,7 @@ public class MuleCoreProcessorComponent extends AbstractProcessorComponent {
 
   @Override
   protected List<String> getOperations() {
-    return Collections.singletonList("flow-ref");
+    return Arrays.asList("flow-ref", "choice", "first-successful", "scatter-gather", "round-robin");
   }
 
   @Override
@@ -40,9 +39,8 @@ public class MuleCoreProcessorComponent extends AbstractProcessorComponent {
 
   @Override
   public boolean canHandle(ComponentIdentifier componentIdentifier) {
-    return super.canHandle(componentIdentifier)
-        || (componentIdentifier instanceof TypedComponentIdentifier
-            && scopes.contains(((TypedComponentIdentifier) componentIdentifier).getType()));
+    System.out.println("Can handle " + componentIdentifier + " " + super.canHandle(componentIdentifier));
+    return super.canHandle(componentIdentifier);
   }
 
   @Override

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/FlowSpan.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/FlowSpan.java
@@ -97,7 +97,7 @@ public class FlowSpan implements Serializable {
     Span span = spanBuilder.startSpan();
     ProcessorSpan ps = new ProcessorSpan(span, traceComponent.getLocation(), transactionId,
         traceComponent.getStartTime(), flowName).setTags(traceComponent.getTags());
-    childSpans.put(traceComponent.contextScopedLocation(), ps);
+    childSpans.putIfAbsent(traceComponent.contextScopedLocation(), ps);
     return ps;
   }
 

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/ComponentsUtil.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/ComponentsUtil.java
@@ -71,6 +71,7 @@ public class ComponentsUtil {
       if (parts.size() > 2) {
         int routeIndex = parts.size() - 3;
         LocationPart parentPart = parts.get(routeIndex);
+        System.out.println("parentPart: " + parentPart);
         parentLocation = parentPart
             .getPartIdentifier()
             .filter(ComponentsUtil::isRoute)
@@ -114,7 +115,8 @@ public class ComponentsUtil {
 
   public static boolean isRoute(TypedComponentIdentifier tci) {
     Objects.requireNonNull(tci, "Component Identifier cannot be null");
-    return tci.getIdentifier().getName().equals("route");
+    return tci.getIdentifier().getName().equals("route")
+        || ROUTE.equals(tci.getType());
   }
 
   public static boolean isFlowTrace(TraceComponent traceComponent) {

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleCoreFlowsNoSpanAllTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleCoreFlowsNoSpanAllTest.java
@@ -1,0 +1,92 @@
+package com.avioconsulting.mule.opentelemetry;
+
+import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.test.DelegatedLoggingSpanTestExporter;
+import org.assertj.core.api.SoftAssertions;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mule.runtime.core.api.event.CoreEvent;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.test.DelegatedLoggingSpanTestExporter.spanQueue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.awaitility.Awaitility.await;
+
+public class MuleCoreFlowsNoSpanAllTest extends AbstractMuleArtifactTraceTest {
+
+  @Override
+  protected String getConfigFile() {
+    return "mule-core-flows.xml";
+  }
+
+  @Override
+  protected void doSetUpBeforeMuleContextCreation() throws Exception {
+    super.doSetUpBeforeMuleContextCreation();
+    System.setProperty("mule.otel.span.processors.enable", "false");
+  }
+
+  @Override
+  protected void doTearDownAfterMuleContextDispose() throws Exception {
+    super.doTearDownAfterMuleContextDispose();
+    System.clearProperty("mule.otel.span.processors.enable");
+  }
+
+  @Test
+  public void testFlowControls_Choice() throws Exception {
+    CoreEvent coreEvent = flowRunner("flow-controls:choice-\\get-value")
+        .run();
+    await().untilAsserted(() -> assertThat(spanQueue)
+        .hasSize(5));
+    Map<Object, Set<String>> groupedSpans = groupSpanByParent();
+    System.out.println(groupedSpans);
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(groupedSpans)
+        .hasEntrySatisfying("flow-controls:choice-\\get-value", val -> assertThat(val)
+            .contains(
+                "flow-controls:choice-\\get-value",
+                "choice:Choice-Control"));
+    softly.assertThat(groupedSpans)
+        .hasEntrySatisfying("choice:Choice-Control", val -> assertThat(val)
+            .containsAnyOf(
+                "flow-controls:choice-\\get-value/processors/1/route/0",
+                "flow-controls:choice-\\get-value/processors/1/route/1"));
+    if (groupedSpans.containsKey("flow-controls:choice-\\get-value/processors/1/route/0")) {
+      softly.assertThat(groupedSpans)
+          .hasEntrySatisfying("flow-controls:choice-\\get-value/processors/1/route/0", val -> assertThat(val)
+              .contains(
+                  "flow-ref:flow-ref"));
+    } else {
+      softly.assertThat(groupedSpans)
+          .hasEntrySatisfying("flow-controls:choice-\\get-value/processors/1/route/1", val -> assertThat(val)
+              .contains(
+                  "flow-ref:flow-ref"));
+    }
+    softly.assertThat(groupedSpans)
+        .hasEntrySatisfying("flow-ref:flow-ref", val -> assertThat(val)
+            .contains(
+                "simple-flow-logger"));
+    softly.assertAll();
+  }
+
+  @NotNull
+  private Map<Object, Set<String>> groupSpanByParent() {
+    // Find the root span
+    DelegatedLoggingSpanTestExporter.Span root = spanQueue.stream()
+        .filter(span -> span.getParentSpanContext().getSpanId().equals("0000000000000000")).findFirst().get();
+
+    // Create a lookup of span id and name
+    Map<String, String> idNameMap = spanQueue.stream().collect(Collectors.toMap(
+        DelegatedLoggingSpanTestExporter.Span::getSpanId, DelegatedLoggingSpanTestExporter.Span::getSpanName));
+
+    Map<Object, Set<String>> groupedSpans = spanQueue.stream()
+        .collect(Collectors.groupingBy(
+            span -> idNameMap.getOrDefault(span.getParentSpanContext().getSpanId(), root.getSpanName()),
+            Collectors.mapping(DelegatedLoggingSpanTestExporter.Span::getSpanName, Collectors.toSet())));
+    return groupedSpans;
+  }
+
+}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/test/util/TestInterceptionEvent.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/test/util/TestInterceptionEvent.java
@@ -124,6 +124,11 @@ public class TestInterceptionEvent implements InterceptionEvent {
       return id;
     }
 
+    // @Override
+    public String getRootId() {
+      return id;
+    }
+
     @Override
     public String getCorrelationId() {
       return correlationId;

--- a/src/test/resources/mule-core-flows.xml
+++ b/src/test/resources/mule-core-flows.xml
@@ -57,6 +57,32 @@ http://www.mulesoft.org/schema/mule/tracing http://www.mulesoft.org/schema/mule/
 			</route>
 		</scatter-gather>
 	</flow>
+
+	<flow name="flow-controls:first-successful-\get-value"  >
+		<logger level="INFO" doc:name="FirstLogger"  />
+		<first-successful doc:name="First-Successful-Control"  >
+			<route >
+				<logger level="INFO" doc:name="FirstSuccess1"  />
+			</route>
+			<route >
+				<logger level="INFO" doc:name="FirstSuccess2"  />
+			</route>
+		</first-successful>
+	</flow>
+
+	<flow name="flow-controls:choice-\get-value"  >
+		<logger level="INFO" doc:name="FirstLogger"  />
+		<choice doc:name="Choice-Control"  >
+			<when expression="#[random() * 10 &gt; 5]">
+				<logger level="INFO" doc:name="ChoiceWhen"  />
+				<flow-ref name="simple-flow-logger"/>
+			</when>
+			<otherwise >
+				<logger level="INFO" doc:name="ChoiceDefault"  />
+				<flow-ref name="simple-flow-logger"/>
+			</otherwise>
+		</choice>
+	</flow>
 	<flow name="flow-controls:round-robin:\get-value"  >
 		<logger level="INFO" doc:name="FirstLogger"  />
 		<round-robin doc:name="Round-Robin-Control"  >
@@ -141,6 +167,10 @@ http://www.mulesoft.org/schema/mule/tracing http://www.mulesoft.org/schema/mule/
 	<sub-flow name="simple-subflow-logger">
 		<logger level="INFO" message="#['Simple flow']" doc:name="SimpleLogger" />
 	</sub-flow>
+
+	<flow name="simple-flow-logger">
+		<logger level="INFO" message="#['Simple flow']" doc:name="SimpleLogger" />
+	</flow>
 
 	<flow name="mule-core-flow-1"  >
 		<logger level="INFO" doc:name="FirstLogger"  />


### PR DESCRIPTION
Fixes the parent-child span relationship logic to not fail in Runtime 4.4 which changed how router components are identified.