### PR TITLE
fix: otlp logs HTTP endpoint

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporter.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporter.java
@@ -23,6 +23,7 @@ public class OtlpExporter extends AbstractExporter {
   public static final String OTEL_EXPORTER_OTLP_ENDPOINT = "otel.exporter.otlp.endpoint";
   public static final String OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "otel.exporter.otlp.traces.endpoint";
   public static final String OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "otel.exporter.otlp.metrics.endpoint";
+  public static final String OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "otel.exporter.otlp.logs.endpoint";
   public static final String OTEL_EXPORTER_OTLP_COMPRESSION = "otel.exporter.otlp.compression";
   public static final String OTEL_EXPORTER_OTLP_HEADERS = "otel.exporter.otlp.headers";
   @Parameter
@@ -101,6 +102,7 @@ public class OtlpExporter extends AbstractExporter {
     if (protocol.equals(Protocol.HTTP_PROTOBUF)) {
       config.put(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, getSignalEndpoint("traces"));
       config.put(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, getSignalEndpoint("metrics"));
+      config.put(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, getSignalEndpoint("logs"));
     }
     if (!OtlpRequestCompression.NONE.equals(requestCompression)) {
       config.put(OTEL_EXPORTER_OTLP_COMPRESSION, requestCompression.getValue());

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporterTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporterTest.java
@@ -15,15 +15,17 @@ public class OtlpExporterTest {
     java.util.List<Header> headers = new java.util.ArrayList<>();
     headers.add(new Header("test", "value"));
     headers.add(new Header("test2", "value2"));
-    OtlpExporter otlpExporter = new OtlpExporter("http://localhost", OtlpExporter.Protocol.HTTP_PROTOBUF,
+    OtlpExporter otlpExporter = new OtlpExporter("http://localhost/v1", OtlpExporter.Protocol.HTTP_PROTOBUF,
         OtlpExporter.OtlpRequestCompression.GZIP, headers);
     assertThat(otlpExporter.getExporterProperties())
         .containsEntry(OTEL_TRACES_EXPORTER_KEY, OTLP)
         .containsEntry(OTEL_EXPORTER_OTLP_COMPRESSION, OtlpExporter.OtlpRequestCompression.GZIP.getValue())
         .containsEntry(OTEL_EXPORTER_OTLP_PROTOCOL, Protocol.HTTP_PROTOBUF.getValue())
         .containsEntry(OTEL_EXPORTER_OTLP_HEADERS, "test=value,test2=value2")
-        .containsEntry(OTEL_EXPORTER_OTLP_ENDPOINT, "http://localhost")
-        .containsEntry(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, "http://localhost/traces");
+        .containsEntry(OTEL_EXPORTER_OTLP_ENDPOINT, "http://localhost/v1")
+        .containsEntry(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, "http://localhost/v1/traces")
+        .containsEntry(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, "http://localhost/v1/logs")
+        .containsEntry(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, "http://localhost/v1/metrics");
   }
 
   @Test


### PR DESCRIPTION
OTLP logs export was failing when using HTTP_PROTOBUF with the exporter endpoint set to `{host}/v1` URL. Traces and Metrics worked as expected but logs were failing with a 404 error. This PR initializes the log endpoint when using the HTTP PROTOBUF.