### PR TITLE
feat: add context and tags operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.avioconsulting.mule</groupId>
     <artifactId>mule-opentelemetry-module</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
 
     <parent>

--- a/src/docs/asciidoc/module-config.adoc
+++ b/src/docs/asciidoc/module-config.adoc
@@ -322,8 +322,8 @@ To disable span generation for all processors in a specific namespace, set the `
 <opentelemetry:mule-component namespace="os" name="*" />
 ----
 
-==== Custom Tags
-In addition to all the trace attributes captured by the module, it is possible to add custom tags to the current trace using an *operation* `opentelemetry:add-custom-tags`.
+==== Add Custom Transaction Tags
+In addition to all the trace attributes captured by the module, it is possible to add custom tags to the current trace using an *operation* `opentelemetry:add-transaction-tags`.
 
 WARNING: All custom tag keys are transformed to `custom.{keyName}`. This also prevents accidentally overriding other standard keys-value pairs in trace tags. Depending on the APM (elastic, etc.) you use, they may be displayed differently. For example, elastic will display them as `label.custom_{keyName}`.
 
@@ -332,12 +332,12 @@ These could be any business data that you may want to capture as a part of your 
 [source,xml]
 .Adding custom tag from variable
 ----
-    <opentelemetry:add-custom-tags doc:name="Add Custom Tags"
+    <opentelemetry:add-transaction-tags doc:name="Add Custom Tags"
                 config-ref="OpenTelemetry_Config">
         <opentelemetry:tags >
             <opentelemetry:tag key="orderNumber" value="#[vars.orderNumber]"/>
         </opentelemetry:tags>
-    </opentelemetry:add-custom-tags>
+    </opentelemetry:add-transaction-tags>
 ----
 
 You can also use dataweave to set the tags.
@@ -345,7 +345,7 @@ You can also use dataweave to set the tags.
 [source,xml]
 .Adding custom tags as DataWeave map
 ----
-    <opentelemetry:add-custom-tags doc:name="Add Custom Tags"
+    <opentelemetry:add-transaction-tags doc:name="Add Custom Tags"
                 config-ref="OpenTelemetry_Config"
                 tags="#[output java --- {orderNumber: payload.orderNumber}]" />
 ----
@@ -462,17 +462,17 @@ If the intercepted processors needs fine-tuning such as including or excluding c
 image::processor-interceptor-configuration.png[600, 600, title="Trace Level - Processor Interception Configuration", align="center"]
 
 ====== Manual Injection
-If needed, `<opentelemetry:get-trace-context />` operation can be used to manually inject trace context into flow.
+If needed, `<opentelemetry:get-current-trace-context />` operation can be used to manually inject trace context into flow.
 
 NOTE: `target` must be used to set operation output to a flow variable.
 
 NOTE: *OTEL_TRACE_CONTEXT.spanId* will be of the flow container span.
 
-WARNING: Similar to link:module-config.adoc#_first_processor_interceptor[First Processor Interceptor], tis context relates to the main flow span and if used for propagation to external services then span rendering may not look accurate.
+WARNING: Similar to link:module-config.adoc#_first_processor_interceptor[First Processor Interceptor], this context relates to the main flow span and if used for propagation to external services then span rendering may not look accurate.
 
 [source,xml]
 ----
-<opentelemetry:get-trace-context doc:name="Get Trace Context" config-ref="OpenTelemetry_Config" target="traceContext"/>
+<opentelemetry:get-current-trace-context doc:name="Get Current Trace Context" config-ref="OpenTelemetry_Config" target="traceContext"/>
 ----
 
 image::manual-context-flow-injection.png[]

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryOperations.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryOperations.java
@@ -1,29 +1,101 @@
 package com.avioconsulting.mule.opentelemetry.internal;
 
 import com.avioconsulting.mule.opentelemetry.internal.connection.OpenTelemetryConnection;
+import com.avioconsulting.mule.opentelemetry.internal.util.OpenTelemetryUtil;
 import org.mule.runtime.extension.api.annotation.Alias;
 import org.mule.runtime.extension.api.annotation.param.Connection;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
+import org.mule.runtime.extension.api.annotation.param.display.Summary;
 import org.mule.runtime.extension.api.runtime.parameter.CorrelationInfo;
 import org.mule.runtime.extension.api.runtime.parameter.ParameterResolver;
+import org.mule.sdk.api.annotation.deprecated.Deprecated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.function.Supplier;
 
 public class OpenTelemetryOperations {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpenTelemetryOperations.class);
+
+  /**
+   * Deprecated: Use Get Current Trace Context instead. When OTEL_TRACE_CONTEXT
+   * does not pre-exist, there is no way for users to get current transaction id.
+   *
+   * @param openTelemetryConnection
+   *            {@link OpenTelemetryConnection} Instance
+   * @param traceTransactionId
+   *            provided by user
+   * @param correlationInfo
+   *            {@link CorrelationInfo} injected by runtime
+   * @return Key-value pair map of context attributes
+   */
   @DisplayName("Get Trace Context")
   @Alias("get-trace-context")
+  @Deprecated(message = "Use Get Current Trace Context instead. When OTEL_TRACE_CONTEXT does not pre-exist, there is no way for users to get current transaction id.", since = "2.3.0", toRemoveIn = "3.0.0")
   public Map<String, String> getTraceContext(@Connection Supplier<OpenTelemetryConnection> openTelemetryConnection,
       @DisplayName("Trace Transaction Id") @Optional(defaultValue = "#[vars.OTEL_TRACE_CONTEXT.TRACE_TRANSACTION_ID]") ParameterResolver<String> traceTransactionId,
       CorrelationInfo correlationInfo) {
+    LOGGER.warn("get-trace-context has been deprecated. Use get-current-trace-context instead");
     return openTelemetryConnection.get().getTraceContext(traceTransactionId.resolve());
+  }
+
+  /**
+   * Get the trace context for current trace transaction.
+   *
+   * @param openTelemetryConnection
+   *            {@link OpenTelemetryConnection} Instance
+   * @param correlationInfo
+   *            {@link CorrelationInfo} (injected by runtime) to extract the
+   *            current event id
+   * @return Key-value pair map of context attributes
+   */
+  @DisplayName("Get Current Trace Context")
+  @Alias("get-current-trace-context")
+  @Summary("Gets the current trace context")
+  public Map<String, String> getCurrentTraceContext(
+      @Connection Supplier<OpenTelemetryConnection> openTelemetryConnection,
+      CorrelationInfo correlationInfo) {
+    String eventTransactionId = OpenTelemetryUtil.getEventTransactionId(correlationInfo.getEventId());
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Getting current context for event Id: {}, correlationId: {}, trace transactionId: {}",
+          correlationInfo.getEventId(), correlationInfo.getCorrelationId(), eventTransactionId);
+    }
+    return openTelemetryConnection.get().getTraceContext(eventTransactionId);
+  }
+
+  /**
+   * Deprecated: Use addTransactionTags instead. When OTEL_TRACE_CONTEXT does not
+   * pre-exist,there is no way for users to get current transaction id.
+   *
+   * @param openTelemetryConnection
+   *            {@link OpenTelemetryConnection} provided by the SDK
+   * @param tags
+   *            {@link Map} of {@link String} Keys and {@link String} Values
+   *            containing the tags. Behavior of null values in the map is
+   *            undefined and not recommended.
+   * @param correlationInfo
+   *            {@link CorrelationInfo} from the runtime
+   */
+  @DisplayName("Add Custom Tags")
+  @Deprecated(message = "Use addTransactionTags instead. When OTEL_TRACE_CONTEXT does not pre-exist, there is no way for users to get current transaction id.", since = "2.3.0", toRemoveIn = "3.0.0")
+  public void addCustomTags(@Connection Supplier<OpenTelemetryConnection> openTelemetryConnection,
+      @DisplayName("Trace Transaction Id") @Optional(defaultValue = "#[vars.OTEL_TRACE_CONTEXT.TRACE_TRANSACTION_ID]") ParameterResolver<String> traceTransactionId,
+      Map<String, String> tags,
+      CorrelationInfo correlationInfo) {
+    LOGGER.warn("add-custom-tags has been deprecated. Use add-transaction-tags instead.");
+    openTelemetryConnection.get().getTransactionStore().addTransactionTags(traceTransactionId.resolve(),
+        "custom",
+        tags);
   }
 
   /**
    * Add custom tags to an ongoing trace transaction. The tags will be added as
    * attributes to the root span of this transaction.
+   * <p>
+   * </p>
    * If the transaction's root span previously contained a mapping for the key,
    * the old value is replaced by the new value.
    *
@@ -36,12 +108,16 @@ public class OpenTelemetryOperations {
    * @param correlationInfo
    *            {@link CorrelationInfo} from the runtime
    */
-  @DisplayName("Add Custom Tags")
-  public void addCustomTags(@Connection Supplier<OpenTelemetryConnection> openTelemetryConnection,
-      @DisplayName("Trace Transaction Id") @Optional(defaultValue = "#[vars.OTEL_TRACE_CONTEXT.TRACE_TRANSACTION_ID]") ParameterResolver<String> traceTransactionId,
+  @DisplayName("Add Transaction Tags")
+  public void addTransactionTags(@Connection Supplier<OpenTelemetryConnection> openTelemetryConnection,
       Map<String, String> tags,
       CorrelationInfo correlationInfo) {
-    openTelemetryConnection.get().getTransactionStore().addTransactionTags(traceTransactionId.resolve(),
+    String eventTransactionId = OpenTelemetryUtil.getEventTransactionId(correlationInfo.getEventId());
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Add Transaction Tags for event Id: {}, correlationId: {}, trace transactionId: {}",
+          correlationInfo.getEventId(), correlationInfo.getCorrelationId(), eventTransactionId);
+    }
+    openTelemetryConnection.get().getTransactionStore().addTransactionTags(eventTransactionId,
         "custom",
         tags);
   }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/OpenTelemetryUtil.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/OpenTelemetryUtil.java
@@ -50,9 +50,20 @@ public class OpenTelemetryUtil {
    * @return String id for the current event
    */
   public static String getEventTransactionId(Event event) {
+    return getEventTransactionId(event.getContext().getId());
+  }
+
+  /**
+   * Creates a unique id for current event processing.
+   *
+   * @param eventId
+   *            {@link Event} to extract id from
+   * @return String id for the current event
+   */
+  public static String getEventTransactionId(String eventId) {
     // For child contexts, the primary id is appended with "_{timeInMillis}".
     // We remove time part to get a unique id across the event processing.
-    return event.getContext().getId().split("_")[0];
+    return eventId.split("_")[0];
   }
 
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsWithoutInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsWithoutInterceptorTest.java
@@ -27,6 +27,12 @@ public class MuleOpenTelemetryOperationsWithoutInterceptorTest extends AbstractM
         "false");
   }
 
+  @Override
+  protected void doTearDownAfterMuleContextDispose() throws Exception {
+    super.doTearDownAfterMuleContextDispose();
+    System.clearProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME);
+  }
+
   @Test
   public void testHttpTracing_WithTransactionTags() throws Exception {
     sendRequest(CORRELATION_ID, "transaction-tags", 200, Collections.emptyMap(),

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsWithoutInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsWithoutInterceptorTest.java
@@ -1,0 +1,70 @@
+package com.avioconsulting.mule.opentelemetry;
+
+import com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.test.DelegatedLoggingSpanTestExporter;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.Test;
+import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.core.api.event.CoreEvent;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static com.avioconsulting.mule.opentelemetry.internal.interceptor.MessageProcessorTracingInterceptorFactory.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class MuleOpenTelemetryOperationsWithoutInterceptorTest extends AbstractMuleArtifactTraceTest {
+
+  @Override
+  protected String getConfigFile() {
+    return "mule-opentelemetry-operations.xml";
+  }
+
+  @Override
+  protected void doSetUpBeforeMuleContextCreation() throws Exception {
+    super.doSetUpBeforeMuleContextCreation();
+    System.setProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME,
+        "false");
+  }
+
+  @Test
+  public void testHttpTracing_WithTransactionTags() throws Exception {
+    sendRequest(CORRELATION_ID, "transaction-tags", 200, Collections.emptyMap(),
+        Collections.singletonMap("orderId", "order123"));
+    await().untilAsserted(() -> assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
+        .hasSize(1)
+        .element(0)
+        .extracting("spanName", "spanKind", "spanStatus")
+        .containsOnly("GET /transaction-tags", "SERVER", "UNSET"));
+    assertThat(DelegatedLoggingSpanTestExporter.spanQueue)
+        .element(0)
+        .extracting("attributes", InstanceOfAssertFactories.map(String.class, String.class))
+        .containsEntry("http.status_code", "200")
+        .containsEntry("custom.orderId", "order123")
+        .containsEntry("custom.quantity", "20")
+        .containsEntry("custom.payload", "Tag Payload");
+  }
+
+  @Test
+  public void testHttpTracing_GetCurrentTraceContext() throws Exception {
+    CoreEvent coreEvent = flowRunner("mule-opentelemetry-get-current-trace-context")
+        .withSourceCorrelationId("test_123").run();
+    assertThat(coreEvent.getVariables())
+        .as("Variables that should contain OTEL injected context")
+        .containsKeys("OTEL_CONTEXT")
+        .as("Variables should not have interceptor innjected context")
+        .doesNotContainKey("OTEL_TRACE_CONTEXT");
+
+    TypedValue<Map<String, String>> otel_context_from_operation = (TypedValue<Map<String, String>>) coreEvent
+        .getVariables().get("OTEL_CONTEXT");
+    assertThat(otel_context_from_operation.getValue())
+        .containsKeys("traceId", "spanId", "spanIdLong", "traceparent", "traceIdLongLowPart",
+            "TRACE_TRANSACTION_ID");
+    assertThat(otel_context_from_operation.getValue())
+        .hasEntrySatisfying("spanIdLong", (value) -> assertThat(Long.parseUnsignedLong(value)).isNotEqualTo(0));
+    assertThat(otel_context_from_operation.getValue())
+        .hasEntrySatisfying("traceIdLongLowPart",
+            (value) -> assertThat(Long.parseUnsignedLong(value)).isNotEqualTo(0));
+  }
+
+}

--- a/src/test/resources/mule-opentelemetry-operations.xml
+++ b/src/test/resources/mule-opentelemetry-operations.xml
@@ -27,10 +27,38 @@ http://www.mulesoft.org/schema/mule/opentelemetry http://www.mulesoft.org/schema
         <logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
     </flow>
 
+    <flow name="mule-opentelemetry-transaction-tags" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+        <http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/transaction-tags"/>
+        <logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
+        <opentelemetry:add-transaction-tags doc:name="Add custom tags" doc:id="3e5c38f9-a197-4ee6-bb1a-9419e69f9fc5" config-ref="OpenTelemetry_Config">
+            <opentelemetry:tags>
+                <opentelemetry:tag key="orderId" value="#[attributes.queryParams.orderId]" />
+                <opentelemetry:tag key="quantity" value="20" />
+            </opentelemetry:tags>
+        </opentelemetry:add-transaction-tags>
+        <set-variable variableName="httpStatus" value="#[200]"/>
+        <set-payload value="Tag Payload" doc:name="Set Payload" doc:id="6bb91307-b173-4256-8c64-491dad475af7" />
+        <opentelemetry:add-transaction-tags doc:name="Add Transaction tags" doc:id="937c3f56-019e-4f69-b3bf-1c9dd7ac6988" config-ref="OpenTelemetry_Config">
+            <opentelemetry:tags >
+                <opentelemetry:tag key="payload" value="#[payload]" />
+            </opentelemetry:tags>
+        </opentelemetry:add-transaction-tags>
+        <logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
+    </flow>
+
     <flow name="mule-opentelemetry-get-trace-context" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
         <http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/tracecontext"/>
         <logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
         <opentelemetry:get-trace-context doc:name="Get Trace Context" doc:id="50381ac8-89c8-4993-abdd-7d1af518ea2d" config-ref="OpenTelemetry_Config" target="OTEL_CONTEXT"/>
+        <set-variable variableName="httpStatus" value="#[200]"/>
+        <set-payload value="#[output json --- vars.OTEL_CONTEXT]" doc:name="Set Payload" doc:id="110a2c1c-3824-4358-87e5-74c9c489f174" mimeType="text/plain" />
+        <logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />
+    </flow>
+
+    <flow name="mule-opentelemetry-get-current-trace-context" doc:id="ddcac188-d00c-4614-ba69-5deef8575938" >
+        <http:listener doc:name="Listener" doc:id="96ac0ccd-1027-495e-9dbd-57f176233ff3" config-ref="HTTP_Listener_config" path="/current-trace-context"/>
+        <logger level="INFO" doc:name="Logger" doc:id="97393612-d33a-466f-b9b5-600a21098532" />
+        <opentelemetry:get-current-trace-context doc:name="Get Current Trace Context" doc:id="50381ac8-89c8-4993-abdd-7d1af518ea2d" config-ref="OpenTelemetry_Config" target="OTEL_CONTEXT"/>
         <set-variable variableName="httpStatus" value="#[200]"/>
         <set-payload value="#[output json --- vars.OTEL_CONTEXT]" doc:name="Set Payload" doc:id="110a2c1c-3824-4358-87e5-74c9c489f174" mimeType="text/plain" />
         <logger level="INFO" doc:name="Logger" doc:id="f0b7d26d-3f66-4bed-afeb-f70fa8d739ec" />


### PR DESCRIPTION
Deprecates existing two operations due to trace transaction id visibility -

- get-trace-context
- add-custom-tags

Adds new replacement operations - 

- get-current-trace-context
- add-transaction-tags