### PR TITLE
feat: subflow spans with notifications and context operation

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/traces/ComponentEventContext.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/traces/ComponentEventContext.java
@@ -99,7 +99,11 @@ public interface ComponentEventContext {
    * @return String
    */
   default String contextScopedLocation() {
-    return getEventContextId() + "/" + getLocation();
+    return contextScopedLocationFor(getEventContextId(), getLocation());
+  }
+
+  static String contextScopedLocationFor(String eventContextId, String location) {
+    return eventContextId + "/" + location;
   }
 
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryOperations.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryOperations.java
@@ -1,7 +1,9 @@
 package com.avioconsulting.mule.opentelemetry.internal;
 
+import com.avioconsulting.mule.opentelemetry.api.traces.ComponentEventContext;
 import com.avioconsulting.mule.opentelemetry.internal.connection.OpenTelemetryConnection;
 import com.avioconsulting.mule.opentelemetry.internal.util.OpenTelemetryUtil;
+import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.extension.api.annotation.Alias;
 import org.mule.runtime.extension.api.annotation.param.Connection;
 import org.mule.runtime.extension.api.annotation.param.Optional;
@@ -57,13 +59,16 @@ public class OpenTelemetryOperations {
   @Summary("Gets the current trace context")
   public Map<String, String> getCurrentTraceContext(
       @Connection Supplier<OpenTelemetryConnection> openTelemetryConnection,
-      CorrelationInfo correlationInfo) {
+      CorrelationInfo correlationInfo, ComponentLocation location) {
     String eventTransactionId = OpenTelemetryUtil.getEventTransactionId(correlationInfo.getEventId());
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Getting current context for event Id: {}, correlationId: {}, trace transactionId: {}",
-          correlationInfo.getEventId(), correlationInfo.getCorrelationId(), eventTransactionId);
+      LOGGER.debug(
+          "Getting current context for event Id: {}, correlationId: {}, trace transactionId: {} at location {} in container {}",
+          correlationInfo.getEventId(), correlationInfo.getCorrelationId(), eventTransactionId,
+          location.getLocation(), location.getRootContainerName());
     }
-    return openTelemetryConnection.get().getTraceContext(eventTransactionId);
+    return openTelemetryConnection.get().getTraceContext(eventTransactionId, ComponentEventContext
+        .contextScopedLocationFor(correlationInfo.getEventId(), location.getRootContainerName()));
   }
 
   /**

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleCoreFlowsNoSpanAllTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleCoreFlowsNoSpanAllTest.java
@@ -102,21 +102,4 @@ public class MuleCoreFlowsNoSpanAllTest extends AbstractMuleArtifactTraceTest {
     System.out.println(groupedSpans);
   }
 
-  @NotNull
-  private Map<Object, Set<String>> groupSpanByParent() {
-    // Find the root span
-    DelegatedLoggingSpanTestExporter.Span root = spanQueue.stream()
-        .filter(span -> span.getParentSpanContext().getSpanId().equals("0000000000000000")).findFirst().get();
-
-    // Create a lookup of span id and name
-    Map<String, String> idNameMap = spanQueue.stream().collect(Collectors.toMap(
-        DelegatedLoggingSpanTestExporter.Span::getSpanId, DelegatedLoggingSpanTestExporter.Span::getSpanName));
-
-    Map<Object, Set<String>> groupedSpans = spanQueue.stream()
-        .collect(Collectors.groupingBy(
-            span -> idNameMap.getOrDefault(span.getParentSpanContext().getSpanId(), root.getSpanName()),
-            Collectors.mapping(DelegatedLoggingSpanTestExporter.Span::getSpanName, Collectors.toSet())));
-    return groupedSpans;
-  }
-
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleCoreFlowsWithoutInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleCoreFlowsWithoutInterceptorTest.java
@@ -1,0 +1,64 @@
+package com.avioconsulting.mule.opentelemetry;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+import org.mule.runtime.core.api.event.CoreEvent;
+
+import java.util.Map;
+import java.util.Set;
+
+import static com.avioconsulting.mule.opentelemetry.internal.interceptor.MessageProcessorTracingInterceptorFactory.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
+import static com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.test.DelegatedLoggingSpanTestExporter.spanQueue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class MuleCoreFlowsWithoutInterceptorTest extends AbstractMuleArtifactTraceTest {
+
+  @Override
+  protected String getConfigFile() {
+    return "mule-core-flows.xml";
+  }
+
+  @Override
+  protected void doSetUpBeforeMuleContextCreation() throws Exception {
+    super.doSetUpBeforeMuleContextCreation();
+    System.setProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME,
+        "false");
+  }
+
+  @Override
+  protected void doTearDownAfterMuleContextDispose() throws Exception {
+    super.doTearDownAfterMuleContextDispose();
+    System.clearProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME);
+  }
+
+  @Test
+  public void testFlowRefInvocations_withCurrentContextOperations() throws Exception {
+    CoreEvent event = flowRunner("root-flow").run();
+    await().untilAsserted(() -> assertThat(spanQueue)
+        .hasSize(11));
+    Map<Object, Set<String>> groupedSpans = groupSpanByParent();
+    System.out.println(groupedSpans);
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(groupedSpans)
+        .hasEntrySatisfying("root-flow", val -> assertThat(val)
+            .containsOnly(
+                "root-flow", "logger:root-flow:FirstRootLogger",
+                "get-current-trace-context:root-flow:Get Current Trace Context",
+                "flow-ref:root-flow:simple-flow", "simple-flow"));
+    softly.assertThat(groupedSpans).hasEntrySatisfying("simple-flow",
+        val -> assertThat(val).containsOnly("flow-ref:simple-flow:simple-subflow-logger",
+            "get-current-trace-context:simple-flow:Get Current Trace Context",
+            "logger:simple-flow:FirstSimpleLogger"));
+    softly.assertThat(groupedSpans)
+        .as("Sub-flow span created from the flow-ref notification and context")
+        .hasEntrySatisfying("flow-ref:simple-flow:simple-subflow-logger",
+            val -> assertThat(val).containsOnly("simple-subflow-logger"));
+    softly.assertThat(groupedSpans).hasEntrySatisfying("simple-subflow-logger",
+        val -> assertThat(val).containsOnly(
+            "get-current-trace-context:simple-subflow-logger:Get Current Trace Context",
+            "logger:simple-subflow-logger:SimpleLogger"));
+    softly.assertAll();
+  }
+
+}

--- a/src/test/resources/mule-core-flows.xml
+++ b/src/test/resources/mule-core-flows.xml
@@ -29,6 +29,9 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
 	<http:listener-config name="HTTP_Listener_config" doc:name="HTTP Listener config" doc:id="79881531-bfaa-49fd-8227-b67e35d64cf8" >
 		<http:listener-connection host="0.0.0.0" port="${http.port}" />
 	</http:listener-config>
+	<sub-flow name="tracing-add-context">
+		<opentelemetry:get-current-trace-context doc:name="root-flow:Get Current Trace Context" doc:id="f747d5ce-d185-42b5-ad79-075b5aac5b7d" config-ref="OpenTelemetry_Config" target="OTEL_TRACE_CONTEXT"/>
+	</sub-flow>
 	<http:request-config name="SELF_HTTP_Request_configuration" doc:name="HTTP Request configuration" doc:id="c18eed36-eb42-4c29-abc9-9e7a2c6049e1" >
 		<http:request-connection host="0.0.0.0" port="${http.port}"/>
 			<http:default-headers >
@@ -199,13 +202,19 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
 		<set-payload mimeType="text/plain" value="Greetings of the day!"/>
 	</flow>
 
-
+	<flow name="root-flow">
+		<opentelemetry:get-current-trace-context doc:name="root-flow:Get Current Trace Context" doc:id="f747d5ce-d185-42b5-ad79-075b5aac5b7d" config-ref="OpenTelemetry_Config" target="OTEL_TRACE_CONTEXT"/>
+		<logger level="INFO" message="#['Root flow']" doc:name="root-flow:FirstRootLogger" />
+		<flow-ref doc:name="root-flow:simple-flow" name="simple-flow"/>
+	</flow>
 	<flow name="simple-flow">
-		<logger level="INFO" message="#['Simple flow']" doc:name="FirstSimpleLogger" />
-		<flow-ref name="simple-subflow-logger"/>
+		<opentelemetry:get-current-trace-context doc:name="simple-flow:Get Current Trace Context" doc:id="f747d5ce-d185-42b5-ad79-075b5aac5b7d" config-ref="OpenTelemetry_Config" target="OTEL_TRACE_CONTEXT"/>
+		<logger level="INFO" message="#['Simple flow']" doc:name="simple-flow:FirstSimpleLogger" />
+		<flow-ref doc:name="simple-flow:simple-subflow-logger" name="simple-subflow-logger"/>
 	</flow>
 	<sub-flow name="simple-subflow-logger">
-		<logger level="INFO" message="#['Simple flow']" doc:name="SimpleLogger" />
+		<opentelemetry:get-current-trace-context doc:name="simple-subflow-logger:Get Current Trace Context" doc:id="f747d5ce-d185-42b5-ad79-075b5aac5b7d" config-ref="OpenTelemetry_Config" target="OTEL_TRACE_CONTEXT"/>
+		<logger level="INFO" message="#['Simple flow']" doc:name="simple-subflow-logger:SimpleLogger" />
 	</sub-flow>
 	<flow name="simple-flow-to-flow">
 		<logger level="INFO" message="#['Simple flow']" doc:name="FirstSimpleLogger" />


### PR DESCRIPTION
- Create subflow spans when processing flow-ref notifications. 
- The current context operation is fixed to use current location so that when context is propagated, it does not always use root context.