### PR TITLE
fix: set flow span status on error

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/FlowProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/FlowProcessorComponent.java
@@ -6,6 +6,7 @@ import com.avioconsulting.mule.opentelemetry.api.traces.TraceComponent;
 import com.avioconsulting.mule.opentelemetry.internal.connection.TraceContextHandler;
 import com.avioconsulting.mule.opentelemetry.internal.processor.service.ProcessorComponentService;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
@@ -116,6 +117,9 @@ public class FlowProcessorComponent extends AbstractProcessorComponent {
   public TraceComponent getSourceEndTraceComponent(EnrichedServerNotification notification,
       TraceContextHandler traceContextHandler) {
     TraceComponent traceComponent = getEndTraceComponent(notification).withSpanKind(SpanKind.SERVER);
+    if (notification.getException() != null) {
+      traceComponent.withStatsCode(StatusCode.ERROR);
+    }
     ComponentIdentifier sourceIdentifier = getSourceIdentifier(notification);
     if (sourceIdentifier == null) {
       return traceComponent;

--- a/src/test/resources/mule-core-flows.xml
+++ b/src/test/resources/mule-core-flows.xml
@@ -250,4 +250,18 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
 		<logger level="INFO" doc:name="ParentFirstLogger"  />
 		<flow-ref name="#[vars.targetFlow]" doc:name="target-flow-call"/>
 	</flow>
+
+	<flow name="mule-core-call-error-flow"  >
+		<logger level="INFO" doc:name="Some-Parent-Logger"  />
+		<flow-ref name="mule-core-error-flow" doc:name="target-flow-call"/>
+		<error-handler>
+			<on-error-continue>
+				<logger level="ERROR" doc:name="Error Logger"  />
+			</on-error-continue>
+		</error-handler>
+	</flow>
+	<flow name="mule-core-error-flow"  >
+		<logger level="INFO" doc:name="Some-Logger"  />
+		<raise-error doc:name="Raise error" description="Random failure" type="APP:RANDOM_FAILURE"/>
+	</flow>
 </mule>


### PR DESCRIPTION
When the flow ends with an exception, the flow span status should be "ERROR." However, protocol-specific processor status can still override this if needed. 