### PR TITLE
feat: rewrite intercept functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>1.3.0-7</version>
   </parent>
   <artifactId>mule-opentelemetry-module</artifactId>
-  <version>2.7.1-SNAPSHOT</version>
+  <version>2.8.0-SNAPSHOT</version>
   <packaging>mule-extension</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/docs/asciidoc/module-config.adoc
+++ b/src/docs/asciidoc/module-config.adoc
@@ -577,17 +577,20 @@ For the context propagation accuracy, certain processors are intercepted to inje
 
 NOTE: *OTEL_TRACE_CONTEXT.spanId* will be of the span of the intercepted component.
 
-By default, any processors in the `ee,mule,validations,aggregators,json,oauth,scripting,tracing,oauth2-provider,xml,wss,spring,java,avio-logger` namespaces are excluded from this context injection, with one exception.
+The connector is pre-configured to intercept following connector operations -
 
-There is one exception in `mule` namespace - `flow-ref`. All `flow-ref` 's are intercepted for context injection. Module's flow processing is capable of extracting this flow-ref context to create accurate parent-child span relationship between calling and referenced flows.
-
-All other processors such as `http:request`, `anypoint-mq:publish` etc. are intercepted and context is injected.
+.List of intercepted operations
+,===
+include::../../main/resources/com/avioconsulting/mule/opentelemetry/internal/interceptor/intercept-components.txt[lines=5..-1]
+,===
 
 As a result of this, for example, when `http:request` makes an outbound request and context is link:module-config.adoc#_http_request_context_injection[injected], `http:request` processor's span is propagated as a prent span.
 
 image::span-parent-child-elastic-view.png[600, 600, title="Span View in Elastic APM", align="center"]
 
 If the intercepted processors needs fine-tuning such as including or excluding certain processors then it can be done in the Trace Level global configuration.
+
+WARNING: Excluding the intercepted components may affect the context propagation.
 
 image::processor-interceptor-configuration.png[600, 600, title="Trace Level - Processor Interception Configuration", align="center"]
 

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/TraceLevelConfiguration.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/TraceLevelConfiguration.java
@@ -4,6 +4,7 @@ import org.mule.runtime.extension.api.annotation.param.NullSafe;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
+import org.mule.runtime.extension.api.annotation.param.display.Example;
 import org.mule.runtime.extension.api.annotation.param.display.Placement;
 import org.mule.runtime.extension.api.annotation.param.display.Summary;
 
@@ -22,7 +23,7 @@ public class TraceLevelConfiguration {
   @Parameter
   @NullSafe
   @Optional
-  @Placement(order = 1)
+  @Placement(order = 2)
   @DisplayName(value = "Disable Spans for")
   @Summary("When generating spans for all processors, this list defines the processors that should be skipped from tracing. No spans will be generated for these components.")
   private List<MuleComponent> ignoreMuleComponents;
@@ -30,15 +31,16 @@ public class TraceLevelConfiguration {
   @Parameter
   @NullSafe
   @Optional
-  @Placement(order = 1)
+  @Placement(order = 3)
   @DisplayName(value = "Disable Interception for")
-  @Summary("Module uses message processor interception mechanism to inject trace context variable. Any specific message processor (namespace:name) or specific namespace (namespace:*) can be excluded from this interception process.")
+  @Example(value = "<opentelemetry:mule-component namespace=\"http\" name=\"requet\" />")
+  @Summary("Module uses message processor interception mechanism to inject trace context variable. Any specific message processor (namespace:name) or specific namespace (namespace:*) can be excluded from this interception process. See Context Propagation docs for default included.")
   private List<MuleComponent> interceptionDisabledComponents;
 
   @Parameter
   @NullSafe
   @Optional
-  @Placement(order = 2)
+  @Placement(order = 4)
   @DisplayName(value = "Enable Interception for")
   @Summary("Module uses message processor interception mechanism to inject trace context variable. Any specific message processor (namespace:name) or specific namespace (namespace:*) can be included from this interception process.")
   private List<MuleComponent> interceptionEnabledComponents;

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/providers/OpenTelemetryMetricsProvider.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/providers/OpenTelemetryMetricsProvider.java
@@ -23,14 +23,6 @@ public interface OpenTelemetryMetricsProvider<T extends OpenTelemetryMetricsConf
   void stop();
 
   /**
-   * Add a single component location for capturing metrics.
-   *
-   * @param location
-   *            {@link String} value of target processor
-   */
-  void addMeteredComponent(String location);
-
-  /**
    * This method is called for capturing Mule Processor event metrics such as
    * start
    * or end of the execution.

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryMetricsProviderCollection.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryMetricsProviderCollection.java
@@ -26,11 +26,6 @@ public class OpenTelemetryMetricsProviderCollection
   }
 
   @Override
-  public void addMeteredComponent(String location) {
-    this.forEach(provider -> provider.addMeteredComponent(location));
-  }
-
-  @Override
   public void captureProcessorMetrics(Component component, Error error, String location, SpanMeta spanMeta) {
     this.forEach(provider -> provider.captureProcessorMetrics(component, error, location, spanMeta));
   }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/InterceptorProcessorConfig.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/InterceptorProcessorConfig.java
@@ -1,0 +1,173 @@
+package com.avioconsulting.mule.opentelemetry.internal.interceptor;
+
+import com.avioconsulting.mule.opentelemetry.api.config.MuleComponent;
+import com.avioconsulting.mule.opentelemetry.api.config.TraceLevelConfiguration;
+import com.avioconsulting.mule.opentelemetry.internal.processor.MuleCoreProcessorComponent;
+import com.avioconsulting.mule.opentelemetry.internal.util.ComponentsUtil;
+import com.avioconsulting.mule.opentelemetry.internal.util.PropertiesUtil;
+import org.mule.runtime.api.component.ComponentIdentifier;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.core.api.util.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Configuration class for managing the interception of components based on
+ * global and local configurations.
+ * InterceptorProcessorConfig provides methods to set tracing configurations,
+ * update trace configurations,
+ * and determine if a specific component is enabled for interception.
+ *
+ * Interceptors can be completely turned off by setting a system property
+ * mule.otel.interceptor.processor.enable=false.
+ *
+ * Interceptors can be restricted to the first processor in the container (eg.
+ * Flow) by setting system property
+ * mule.otel.interceptor.first.processor.only=true.
+ *
+ * @since 2.8
+ */
+public class InterceptorProcessorConfig {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InterceptorProcessorConfig.class);
+
+  /**
+   * Disable interceptor feature by setting this system property to `false`.
+   * Default `true`.
+   */
+  public static final String MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME = "mule.otel.interceptor.processor.enable";
+  private final boolean INTERCEPTOR_ENABLED_BY_SYS_PROPERTY = PropertiesUtil
+      .getBoolean(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME, true);
+
+  /**
+   * Enable interceptor feature for first processor in the container (eg. Flow) by
+   * setting this system property to `true`. Default `false`.
+   */
+  public static final String MULE_OTEL_INTERCEPTOR_FIRST_PROCESSOR_ONLY = "mule.otel.interceptor.first.processor.only";
+  // Negating the property value since usage is negated
+  private final boolean NOT_FIRST_PROCESSOR_ONLY_MODE = !PropertiesUtil
+      .getBoolean(MULE_OTEL_INTERCEPTOR_FIRST_PROCESSOR_ONLY, false);
+
+  private boolean turnOffTracing = false;
+
+  /**
+   * Components that must be intercepted
+   */
+  private final List<String> interceptInclusions = new ArrayList<>();
+
+  /**
+   * List of components not to intercept. Configured using
+   * {@link TraceLevelConfiguration#interceptionDisabledComponents} on
+   * {@link com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryExtensionConfiguration}.
+   */
+  private List<String> interceptDisabledByConfigComponents = new ArrayList<>();
+
+  /**
+   * List of components to intercept. Configured using
+   * {@link TraceLevelConfiguration#interceptionDisabledComponents} on
+   * {@link com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryExtensionConfiguration}.
+   */
+  private List<String> interceptEnabledByConfigComponents = new ArrayList<>();
+
+  public InterceptorProcessorConfig setTurnOffTracing(boolean turnOffTracing) {
+    this.turnOffTracing = turnOffTracing;
+    return this;
+  }
+
+  public InterceptorProcessorConfig() {
+    setupInterceptComponents();
+  }
+
+  public void updateTraceConfiguration(TraceLevelConfiguration traceLevelConfiguration) {
+    interceptDisabledByConfigComponents = traceLevelConfiguration.getInterceptionDisabledComponents().stream()
+        .map(MuleComponent::toString).collect(Collectors.toList());
+    interceptEnabledByConfigComponents = traceLevelConfiguration.getInterceptionEnabledComponents().stream()
+        .map(MuleComponent::toString).collect(Collectors.toList());
+  }
+
+  /**
+   * Set the default list of components to intercept. This includes some core set
+   * of processors.
+   * Some known connector-operations that can propagate the OpenTelemetry context
+   * to external services,
+   * are also included to ensure the context (span id) references the current
+   * processor instead of flow's span id.
+   *
+   * If users need to include/exclude any components they can do so by using
+   * {@link TraceLevelConfiguration} on
+   * {@link com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryExtensionConfiguration}.
+   */
+  private void setupInterceptComponents() {
+
+    MuleCoreProcessorComponent.CORE_INTERCEPT_SCOPE_ROUTERS
+        .forEach(c -> interceptInclusions.add("mule:" + c));
+
+    try {
+      InputStream interceptedComponentsFile = IOUtils.getResourceAsStream(
+          "com/avioconsulting/mule/opentelemetry/internal/interceptor/intercept-components.txt",
+          InterceptorProcessorConfig.class);
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(interceptedComponentsFile))) {
+        for (String line; (line = reader.readLine()) != null;) {
+          if (line.startsWith("*")) {
+            continue;
+          }
+          String[] split = line.split(":");
+          LOGGER.trace("Attempting to add component to intercept: {}", line);
+          if (split.length == 2) {
+            interceptInclusions.add(line);
+          } else {
+            LOGGER.warn("Unable to parse intercept components entry: {}, skipping this line", line);
+          }
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load interceptor components", e);
+    }
+  }
+
+  public boolean interceptEnabled(ComponentLocation location) {
+    if (!INTERCEPTOR_ENABLED_BY_SYS_PROPERTY) {
+      LOGGER.trace("Interceptors are disabled by system property");
+      return false;
+    }
+    if (turnOffTracing) {
+      LOGGER.trace("Tracing has been turned off by global configuration");
+      return false;
+    }
+    return ComponentsUtil.isFirstProcessor(location) || (NOT_FIRST_PROCESSOR_ONLY_MODE
+        && interceptEnabled(location.getComponentIdentifier().getIdentifier()));
+  }
+
+  private boolean interceptEnabled(ComponentIdentifier componentIdentifier) {
+    String identifier = componentIdentifier.getNamespace() + ":" + componentIdentifier.getName();
+    String wildcardIdentifier = componentIdentifier.getNamespace() + ":*";
+    if ((interceptDisabledByConfigComponents.contains(wildcardIdentifier)
+        && !interceptEnabledByConfigComponents.contains(identifier))
+        || interceptDisabledByConfigComponents.contains(identifier)) {
+      LOGGER.trace("Component {} is disabled by global configuration", identifier);
+      return false;
+    } else if (interceptInclusions.contains(identifier)) {
+      LOGGER.trace("Component {} is enabled by default configuration", identifier);
+      return true;
+    } else if (interceptEnabledByConfigComponents.contains(wildcardIdentifier)
+        || interceptEnabledByConfigComponents.contains(identifier)) {
+      LOGGER.trace("Component {} is enabled by global configuration", identifier);
+      return true;
+    } else {
+      LOGGER.trace("Component {} is not configured for interception, skipping interception", identifier);
+      return false;
+    }
+  }
+
+}

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptor.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptor.java
@@ -59,6 +59,9 @@ public class ProcessorTracingInterceptor implements ProcessorInterceptor {
       ComponentLocation location,
       Map<String, ProcessorParameterValue> parameters,
       InterceptionEvent event) {
+    if (!muleNotificationProcessor.getInterceptorProcessorConfig().interceptEnabled(location)) {
+      return;
+    }
     // Using an instance of MuleNotificationProcessor here.
     // If the tracing is disabled, the module configuration will not initialize
     // connection supplier.

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/notifications/listeners/MuleMessageProcessorNotificationListener.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/notifications/listeners/MuleMessageProcessorNotificationListener.java
@@ -16,11 +16,7 @@ public class MuleMessageProcessorNotificationListener extends AbstractMuleNotifi
 
   @Override
   public void onNotification(MessageProcessorNotification notification) {
-    LOGGER.trace(
-        "===> Received "
-            + notification.getClass().getName()
-            + ":"
-            + notification.getActionName());
+    LOGGER.trace("===> Received {}:{}", notification.getClass().getName(), notification.getActionName());
 
     switch (Integer.parseInt(notification.getAction().getIdentifier())) {
       case MessageProcessorNotification.MESSAGE_PROCESSOR_PRE_INVOKE:

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/notifications/listeners/MulePipelineMessageNotificationListener.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/notifications/listeners/MulePipelineMessageNotificationListener.java
@@ -20,11 +20,7 @@ public class MulePipelineMessageNotificationListener extends AbstractMuleNotific
 
   @Override
   public void onNotification(PipelineMessageNotification notification) {
-    LOGGER.trace(
-        "===> Received "
-            + notification.getClass().getName()
-            + ":"
-            + notification.getActionName());
+    LOGGER.trace("===> Received {}:{}", notification.getClass().getName(), notification.getActionName());
 
     switch (Integer.parseInt(notification.getAction().getIdentifier())) {
       case PipelineMessageNotification.PROCESS_START:

--- a/src/main/resources/com/avioconsulting/mule/opentelemetry/internal/interceptor/intercept-components.txt
+++ b/src/main/resources/com/avioconsulting/mule/opentelemetry/internal/interceptor/intercept-components.txt
@@ -1,0 +1,25 @@
+**CODE: List of Processors to be intercepted using InterceptorProcessorConfig class.
+**DOCS: module-config.adoc includes this file as a documentation
+**
+**NO_COMMENTS_AFTER_THIS
+**Operation**
+http:request
+anypoint-mq:publish
+sqs:send-message
+sqs:send-message-batch
+sns:publish
+amqp:publish
+amqp:publish-consume
+kafka:publish
+kafka:bulk-publish
+azure-service-bus-messaging:send
+azure-service-bus-messaging:send-message-batch
+pubsub:publish-message
+ibm-mq:publish
+ibm-mq:publish-consume
+jms:publish
+jms:publish-consume
+msmq:send
+servicebus:topic-send
+mqtt3:publish
+salesforce-pub-sub:publish-event

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleCoreFlowsWithoutInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleCoreFlowsWithoutInterceptorTest.java
@@ -7,7 +7,7 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import java.util.Map;
 import java.util.Set;
 
-import static com.avioconsulting.mule.opentelemetry.internal.interceptor.MessageProcessorTracingInterceptorFactory.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
+import static com.avioconsulting.mule.opentelemetry.internal.interceptor.InterceptorProcessorConfig.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
 import static com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk.test.DelegatedLoggingSpanTestExporter.spanQueue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryDisabledInterceptorHttpTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryDisabledInterceptorHttpTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.tck.junit4.rule.DynamicPort;
 
-import static com.avioconsulting.mule.opentelemetry.internal.interceptor.MessageProcessorTracingInterceptorFactory.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
+import static com.avioconsulting.mule.opentelemetry.internal.interceptor.InterceptorProcessorConfig.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MuleOpenTelemetryDisabledInterceptorHttpTest extends AbstractMuleArtifactTraceTest {

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsWithoutInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/MuleOpenTelemetryOperationsWithoutInterceptorTest.java
@@ -9,7 +9,7 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import java.util.Collections;
 import java.util.Map;
 
-import static com.avioconsulting.mule.opentelemetry.internal.interceptor.MessageProcessorTracingInterceptorFactory.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
+import static com.avioconsulting.mule.opentelemetry.internal.interceptor.InterceptorProcessorConfig.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/AbstractInternalTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/AbstractInternalTest.java
@@ -2,6 +2,11 @@ package com.avioconsulting.mule.opentelemetry.internal;
 
 import com.avioconsulting.mule.opentelemetry.internal.connection.OpenTelemetryConnection;
 import org.junit.Before;
+import org.mule.runtime.api.component.ComponentIdentifier;
+import org.mule.runtime.api.component.TypedComponentIdentifier;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class AbstractInternalTest {
 
@@ -9,4 +14,16 @@ public abstract class AbstractInternalTest {
   public void setupTests() {
     OpenTelemetryConnection.resetForTest();
   }
+
+  protected TypedComponentIdentifier getComponentIdentifier(String namespace, String name) {
+    TypedComponentIdentifier typedComponentIdentifier = mock(TypedComponentIdentifier.class);
+    ComponentIdentifier componentIdentifier = mock(ComponentIdentifier.class);
+    if (namespace != null)
+      when(componentIdentifier.getNamespace()).thenReturn(namespace);
+    if (name != null)
+      when(componentIdentifier.getName()).thenReturn(name);
+    when(typedComponentIdentifier.getIdentifier()).thenReturn(componentIdentifier);
+    return typedComponentIdentifier;
+  }
+
 }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/InterceptorProcessorConfigDefaultTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/InterceptorProcessorConfigDefaultTest.java
@@ -1,0 +1,86 @@
+package com.avioconsulting.mule.opentelemetry.internal.interceptor;
+
+import com.avioconsulting.mule.opentelemetry.internal.AbstractInternalTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import org.mule.runtime.api.component.ComponentIdentifier;
+import org.mule.runtime.api.component.TypedComponentIdentifier;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.component.location.LocationPart;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class InterceptorProcessorConfigDefaultTest extends AbstractInternalTest {
+
+  @Parameterized.Parameter(value = 0)
+  public String namespace;
+
+  @Parameterized.Parameter(value = 1)
+  public String name;
+
+  @Parameterized.Parameters(name = "{index}: Intercept {0}:{1}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        { "anypoint-mq", "publish" },
+        { "sqs", "send-message" },
+        { "sqs", "send-message-batch" },
+        { "sns", "publish" },
+        { "amqp", "publish" },
+        { "amqp", "publish-consume" },
+        { "kafka", "publish" },
+        { "kafka", "bulk-publish" },
+        { "azure-service-bus-messaging", "send" },
+        { "azure-service-bus-messaging", "send-message-batch" },
+        { "pubsub", "publish-message" },
+        { "ibm-mq", "publish" },
+        { "ibm-mq", "publish-consume" },
+        { "jms", "publish" },
+        { "jms", "publish-consume" },
+        { "msmq", "send" },
+        { "servicebus", "topic-send" },
+        { "mqtt3", "publish" },
+        { "salesforce-pub-sub", "publish-event" },
+        { "mule", "flow-ref" },
+        { "mule", "choice" },
+        { "mule", "first-successful" },
+        { "mule", "until-successful" },
+        { "mule", "scatter-gather" },
+        { "mule", "round-robin" },
+        { "mule", "foreach" },
+        { "mule", "parallel-foreach" },
+        { "mule", "try" }
+    });
+  }
+
+  @Test
+  public void interceptEnabled() {
+    ComponentLocation location = Mockito.mock(ComponentLocation.class);
+    when(location.getRootContainerName()).thenReturn("MyFlow");
+    when(location.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
+
+    TypedComponentIdentifier logger = mock(TypedComponentIdentifier.class);
+    ComponentIdentifier loggerIdentifier = mock(ComponentIdentifier.class);
+    when(loggerIdentifier.getNamespace()).thenReturn(namespace);
+    when(loggerIdentifier.getName()).thenReturn(name);
+    when(logger.getIdentifier()).thenReturn(loggerIdentifier);
+    when(location.getComponentIdentifier()).thenReturn(logger);
+
+    LocationPart part1 = mock(LocationPart.class);
+    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
+    when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
+    when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
+    when(location.getParts()).thenReturn(Arrays.asList(part1));
+    assertThat(
+        new InterceptorProcessorConfig().interceptEnabled(location))
+            .isTrue();
+  }
+}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/InterceptorProcessorConfigTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/InterceptorProcessorConfigTest.java
@@ -1,0 +1,231 @@
+package com.avioconsulting.mule.opentelemetry.internal.interceptor;
+
+import com.avioconsulting.mule.opentelemetry.api.config.MuleComponent;
+import com.avioconsulting.mule.opentelemetry.api.config.TraceLevelConfiguration;
+import com.avioconsulting.mule.opentelemetry.internal.AbstractInternalTest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mule.runtime.api.component.TypedComponentIdentifier;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.component.location.LocationPart;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.avioconsulting.mule.opentelemetry.internal.interceptor.InterceptorProcessorConfig.MULE_OTEL_INTERCEPTOR_FIRST_PROCESSOR_ONLY;
+import static com.avioconsulting.mule.opentelemetry.internal.interceptor.InterceptorProcessorConfig.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class InterceptorProcessorConfigTest extends AbstractInternalTest {
+
+  private @NotNull ComponentLocation getLocation(String namespace, String name) {
+    return getLocationAt(namespace, name, "anything-but-0");
+  }
+
+  private @NotNull ComponentLocation getLocationAtZero(String namespace, String name) {
+    return getLocationAt(namespace, name, "0");
+  }
+
+  private @NotNull ComponentLocation getLocationAt(String namespace, String name, String locationEndPath) {
+    ComponentLocation location = Mockito.mock(ComponentLocation.class);
+    when(location.getRootContainerName()).thenReturn("MyFlow");
+    when(location.getLocation()).thenReturn("MyFlow/processors/" + locationEndPath);
+
+    TypedComponentIdentifier componentIdentifier = getComponentIdentifier(namespace, name);
+    when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
+
+    LocationPart part1 = mock(LocationPart.class);
+    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
+    when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
+    when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
+    when(location.getParts()).thenReturn(Arrays.asList(part1));
+    return location;
+  }
+
+  @Test
+  public void do_not_intercept_wildcard_excluded_processors() {
+
+    ComponentLocation location = getLocation("http", "request");
+
+    TraceLevelConfiguration traceLevelConfiguration = new TraceLevelConfiguration(true, Collections.emptyList(),
+        Collections.singletonList(new MuleComponent("http", "*")), Collections.emptyList());
+
+    InterceptorProcessorConfig interceptorProcessorConfig = new InterceptorProcessorConfig();
+    interceptorProcessorConfig.updateTraceConfiguration(traceLevelConfiguration);
+
+    assertThat(
+        interceptorProcessorConfig.interceptEnabled(location))
+            .isFalse();
+
+  }
+
+  @Test
+  public void do_not_intercept_explicit_excluded_processors() {
+
+    ComponentLocation location = getLocation("http", "request");
+
+    TraceLevelConfiguration traceLevelConfiguration = new TraceLevelConfiguration(true, Collections.emptyList(),
+        Collections.singletonList(new MuleComponent("http", "request")), Collections.emptyList());
+
+    InterceptorProcessorConfig interceptorProcessorConfig = new InterceptorProcessorConfig();
+    interceptorProcessorConfig.updateTraceConfiguration(traceLevelConfiguration);
+
+    assertThat(
+        interceptorProcessorConfig.interceptEnabled(location))
+            .isFalse();
+
+  }
+
+  @Test
+  public void intercept_wildcard_excluded_but_individual_included_processors() {
+
+    ComponentLocation location = getLocation("http", "request");
+
+    TraceLevelConfiguration traceLevelConfiguration = new TraceLevelConfiguration(true, Collections.emptyList(),
+        Collections.singletonList(new MuleComponent("http", "*")),
+        Collections.singletonList(new MuleComponent("http", "request")));
+
+    InterceptorProcessorConfig interceptorProcessorConfig = new InterceptorProcessorConfig();
+    interceptorProcessorConfig.updateTraceConfiguration(traceLevelConfiguration);
+
+    assertThat(
+        interceptorProcessorConfig.interceptEnabled(location))
+            .isTrue();
+
+  }
+
+  @Test
+  public void intercept_wildcard_included_processors() {
+
+    ComponentLocation location = getLocation("some", "processor");
+
+    TraceLevelConfiguration traceLevelConfiguration = new TraceLevelConfiguration(true, Collections.emptyList(),
+        Collections.emptyList(), Collections.singletonList(new MuleComponent("some", "*")));
+
+    InterceptorProcessorConfig interceptorProcessorConfig = new InterceptorProcessorConfig();
+    interceptorProcessorConfig.updateTraceConfiguration(traceLevelConfiguration);
+
+    assertThat(
+        interceptorProcessorConfig.interceptEnabled(location))
+            .isTrue();
+
+  }
+
+  @Test
+  public void intercept_explicit_included_processors() {
+
+    ComponentLocation location = getLocation("some", "processor");
+    ComponentLocation notIncludedLocation = getLocation("some", "diff-processor");
+
+    TraceLevelConfiguration traceLevelConfiguration = new TraceLevelConfiguration(true, Collections.emptyList(),
+        Collections.emptyList(), Collections.singletonList(new MuleComponent("some", "processor")));
+
+    InterceptorProcessorConfig interceptorProcessorConfig = new InterceptorProcessorConfig();
+    interceptorProcessorConfig.updateTraceConfiguration(traceLevelConfiguration);
+
+    assertThat(
+        interceptorProcessorConfig.interceptEnabled(location))
+            .isTrue();
+    assertThat(
+        interceptorProcessorConfig.interceptEnabled(notIncludedLocation))
+            .isFalse();
+
+  }
+
+  @Test
+  public void interceptionDisabledBySystemProperty() {
+    ComponentLocation location = Mockito.mock(ComponentLocation.class);
+    when(location.getRootContainerName()).thenReturn("MyFlow");
+    when(location.getLocation()).thenReturn("MyFlow/processors/0");
+    LocationPart part1 = mock(LocationPart.class);
+    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
+    when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
+    when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
+    when(location.getParts()).thenReturn(Arrays.asList(part1));
+    TypedComponentIdentifier componentIdentifier = getComponentIdentifier(null, null);
+    when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
+
+    assertThat(
+        new InterceptorProcessorConfig().interceptEnabled(location))
+            .as("Interception before system property")
+            .isTrue();
+    System.setProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME, "false");
+
+    assertThat(
+        new InterceptorProcessorConfig().interceptEnabled(location))
+            .as("Interception after system property")
+            .isFalse();
+    System.clearProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME);
+  }
+
+  @Test
+  public void do_not_intercept_anything_that_is_not_configured_and_processor_0() {
+    ComponentLocation location = getLocation("mule", "logger");
+    assertThat(
+        new InterceptorProcessorConfig().interceptEnabled(location))
+            .isFalse();
+  }
+
+  @Test
+  public void intercept_processor_0() {
+    ComponentLocation location = getLocationAtZero("mule", "logger");
+    assertThat(
+        new InterceptorProcessorConfig().interceptEnabled(location))
+            .isTrue();
+  }
+
+  @Test
+  public void do_not_intercept_included_processors_without_processor_zero_enabled() {
+
+    ComponentLocation location = getLocation("some", "processor");
+
+    TraceLevelConfiguration traceLevelConfiguration = new TraceLevelConfiguration(true, Collections.emptyList(),
+        Collections.emptyList(), Collections.singletonList(new MuleComponent("some", "processor")));
+    InterceptorProcessorConfig interceptorProcessorConfig = new InterceptorProcessorConfig();
+    interceptorProcessorConfig.updateTraceConfiguration(traceLevelConfiguration);
+
+    assertThat(
+        interceptorProcessorConfig.interceptEnabled(location))
+            .as("Processor is enabled to intercept and processor zero is disabled")
+            .isTrue();
+
+    // Enable the first processor only mode
+    System.setProperty(MULE_OTEL_INTERCEPTOR_FIRST_PROCESSOR_ONLY, "true");
+    InterceptorProcessorConfig interceptorProcessorConfigWithout0 = new InterceptorProcessorConfig();
+    interceptorProcessorConfigWithout0.updateTraceConfiguration(traceLevelConfiguration);
+
+    assertThat(
+        interceptorProcessorConfigWithout0.interceptEnabled(location))
+            .as("Processor is enabled to intercept and processor zero is enabled")
+            .isFalse();
+    System.clearProperty(MULE_OTEL_INTERCEPTOR_FIRST_PROCESSOR_ONLY);
+  }
+
+  @Test
+  public void interception_disabled_from_global_config_turnoff_flag() {
+    ComponentLocation location = getLocation("some", "processor");
+
+    TraceLevelConfiguration traceLevelConfiguration = new TraceLevelConfiguration(true, Collections.emptyList(),
+        Collections.emptyList(), Collections.singletonList(new MuleComponent("some", "processor")));
+    InterceptorProcessorConfig interceptorProcessorConfig = new InterceptorProcessorConfig();
+    interceptorProcessorConfig
+        .updateTraceConfiguration(traceLevelConfiguration);
+
+    assertThat(
+        interceptorProcessorConfig.interceptEnabled(location))
+            .isTrue();
+
+    // Turn off tracing
+    interceptorProcessorConfig
+        .setTurnOffTracing(true);
+
+    assertThat(
+        interceptorProcessorConfig.interceptEnabled(location))
+            .isFalse();
+  }
+
+}

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/MessageProcessorTracingInterceptorFactoryTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/MessageProcessorTracingInterceptorFactoryTest.java
@@ -1,29 +1,23 @@
 package com.avioconsulting.mule.opentelemetry.internal.interceptor;
 
-import com.avioconsulting.mule.opentelemetry.api.config.MuleComponent;
-import com.avioconsulting.mule.opentelemetry.api.config.TraceLevelConfiguration;
 import com.avioconsulting.mule.opentelemetry.internal.AbstractInternalTest;
 import com.avioconsulting.mule.opentelemetry.internal.connection.OpenTelemetryConnection;
 import com.avioconsulting.mule.opentelemetry.internal.processor.MuleNotificationProcessor;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.TypedComponentIdentifier;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.component.location.LocationPart;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-import static com.avioconsulting.mule.opentelemetry.internal.interceptor.MessageProcessorTracingInterceptorFactory.*;
+import static com.avioconsulting.mule.opentelemetry.internal.interceptor.InterceptorProcessorConfig.MULE_OTEL_INTERCEPTOR_FIRST_PROCESSOR_ONLY;
+import static com.avioconsulting.mule.opentelemetry.internal.interceptor.InterceptorProcessorConfig.MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -39,12 +33,6 @@ public class MessageProcessorTracingInterceptorFactoryTest extends AbstractInter
   @Mock
   OpenTelemetryConnection openTelemetryConnection;
 
-  @Before
-  public void setMocks() {
-    when(muleNotificationProcessor.hasConnection()).thenReturn(true);
-    when(muleNotificationProcessor.getOpenTelemetryConnection()).thenReturn(openTelemetryConnection);
-  }
-
   @Test
   public void get() {
     assertThat(
@@ -53,183 +41,10 @@ public class MessageProcessorTracingInterceptorFactoryTest extends AbstractInter
                 .isInstanceOf(ProcessorTracingInterceptor.class);
   }
 
-  @Test
-  public void notInterceptionNonZeroProcessors() {
-    ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    when(location.getRootContainerName()).thenReturn("MyFlow");
-    when(location.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
-
-    TypedComponentIdentifier logger = mock(TypedComponentIdentifier.class);
-    ComponentIdentifier loggerIdentifier = mock(ComponentIdentifier.class);
-    when(loggerIdentifier.getNamespace()).thenReturn("mule");
-    when(loggerIdentifier.getName()).thenReturn("logger");
-    when(logger.getIdentifier()).thenReturn(loggerIdentifier);
-    when(location.getComponentIdentifier()).thenReturn(logger);
-
-    LocationPart part1 = mock(LocationPart.class);
-    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
-    when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
-    when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
-    when(location.getParts()).thenReturn(Arrays.asList(part1));
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
-            .intercept(location))
-                .isFalse();
-  }
-
-  private TypedComponentIdentifier getComponentIdentifier(String namespace, String name) {
-    TypedComponentIdentifier typedComponentIdentifier = mock(TypedComponentIdentifier.class);
-    ComponentIdentifier componentIdentifier = mock(ComponentIdentifier.class);
-    if (namespace != null)
-      when(componentIdentifier.getNamespace()).thenReturn(namespace);
-    if (name != null)
-      when(componentIdentifier.getName()).thenReturn(name);
-    when(typedComponentIdentifier.getIdentifier()).thenReturn(componentIdentifier);
-    return typedComponentIdentifier;
-  }
-
-  @Test
-  public void interceptDefaultIncludedProcessor() {
-    ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    when(location.getRootContainerName()).thenReturn("MyFlow");
-    when(location.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
-
-    TypedComponentIdentifier componentIdentifier = getComponentIdentifier("mule", "flow-ref");
-    when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
-
-    LocationPart part1 = mock(LocationPart.class);
-    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
-    when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
-    when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
-    when(location.getParts()).thenReturn(Arrays.asList(part1));
-
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
-            .intercept(location))
-                .isTrue();
-  }
-
-  @Test
-  public void interceptNotExcludedProcessor() {
-    ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    when(location.getRootContainerName()).thenReturn("MyFlow");
-    when(location.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
-
-    TypedComponentIdentifier componentIdentifier = getComponentIdentifier("http", "request");
-    when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
-
-    LocationPart part1 = mock(LocationPart.class);
-    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
-    when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
-    when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
-    when(location.getParts()).thenReturn(Arrays.asList(part1));
-
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
-            .intercept(location))
-                .isTrue();
-  }
-
-  @Test
-  public void doNotInterceptExcludedProcessor() {
-    ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    when(location.getRootContainerName()).thenReturn("MyFlow");
-    when(location.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
-
-    TypedComponentIdentifier componentIdentifier = getComponentIdentifier("mule", "logger");
-    when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
-
-    LocationPart part1 = mock(LocationPart.class);
-    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
-    when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
-    when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
-    when(location.getParts()).thenReturn(Arrays.asList(part1));
-
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
-            .intercept(location))
-                .isFalse();
-  }
-
-  @Test
-  public void doNotInterceptWildcardExcludedProcessor() {
-    ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    when(location.getRootContainerName()).thenReturn("MyFlow");
-    when(location.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
-
-    TypedComponentIdentifier componentIdentifier = getComponentIdentifier("http", "request");
-    when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
-
-    LocationPart part1 = mock(LocationPart.class);
-    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
-    when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
-    when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
-    when(location.getParts()).thenReturn(Arrays.asList(part1));
-
-    MuleNotificationProcessor muleNotificationProcessor1 = new MuleNotificationProcessor(null);
-    OpenTelemetryConnection connection = mock(OpenTelemetryConnection.class);
-    muleNotificationProcessor1.init(connection, new TraceLevelConfiguration(true, Collections.emptyList(),
-        Collections.singletonList(new MuleComponent("http", "*")), Collections.emptyList()));
-
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor1, configurationComponentLocator)
-            .intercept(location))
-                .isFalse();
-  }
-
-  @Test
-  public void interceptionDefaultEnabled() {
-    ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    when(location.getRootContainerName()).thenReturn("MyFlow");
-    when(location.getLocation()).thenReturn("MyFlow/processors/0");
-
-    LocationPart part1 = mock(LocationPart.class);
-    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
-    when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
-    when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
-    when(location.getParts()).thenReturn(Arrays.asList(part1));
-
-    TypedComponentIdentifier componentIdentifier = getComponentIdentifier(null, null);
-    when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
-            .intercept(location))
-                .isTrue();
-  }
-
-  @Test
-  public void interceptionDisabledWithTurnOff() {
-    ComponentLocation location = Mockito.mock(ComponentLocation.class);
-
-    LocationPart part1 = mock(LocationPart.class);
-    TypedComponentIdentifier identifier = mock(TypedComponentIdentifier.class);
-
-    TypedComponentIdentifier componentIdentifier = getComponentIdentifier(null, null);
-    when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
-
-    when(openTelemetryConnection.isTurnOffTracing()).thenReturn(true);
-
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
-            .intercept(location))
-                .isFalse();
-  }
-
   private static LocationPart getLocationPart(String path) {
     LocationPart part = mock(LocationPart.class);
     doReturn(part).when(part).getPartPath();
     return part;
-  }
-
-  @Test
-  public void interceptionDisabledDueToNotificationListener() {
-    reset(muleNotificationProcessor);
-    when(muleNotificationProcessor.hasConnection()).thenReturn(false);
-    ComponentLocation location = Mockito.mock(ComponentLocation.class);
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
-            .intercept(location))
-                .isFalse();
   }
 
   @Test
@@ -242,8 +57,6 @@ public class MessageProcessorTracingInterceptorFactoryTest extends AbstractInter
     when(identifier.getType()).thenReturn(TypedComponentIdentifier.ComponentType.FLOW);
     when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
     when(location.getParts()).thenReturn(Arrays.asList(part1));
-    TypedComponentIdentifier componentIdentifier = getComponentIdentifier(null, null);
-    when(location.getComponentIdentifier()).thenReturn(componentIdentifier);
     assertThat(
         new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
             .intercept(location))
@@ -257,82 +70,6 @@ public class MessageProcessorTracingInterceptorFactoryTest extends AbstractInter
                 .as("Interception after system property")
                 .isFalse();
     System.clearProperty(MULE_OTEL_INTERCEPTOR_PROCESSOR_ENABLE_PROPERTY_NAME);
-  }
-
-  @Test
-  public void getInterceptExclusions() {
-    List<MuleComponent> expected = Arrays.stream(
-        "ee,mule,validations,aggregators,json,oauth,scripting,tracing,oauth2-provider,xml,wss,spring,java,avio-logger"
-            .split(","))
-        .map(s -> new MuleComponent(s, "*")).collect(Collectors.toList());
-    assertThat(new MessageProcessorTracingInterceptorFactory(new MuleNotificationProcessor(null),
-        configurationComponentLocator)
-            .getInterceptExclusions())
-                .as("Default Exclusions")
-                .isNotEmpty()
-                .containsExactlyInAnyOrderElementsOf(expected);
-  }
-
-  @Test
-  public void getInterceptExclusionsWithTraceLevelConfig() {
-
-    List<MuleComponent> expected = Arrays.stream(
-        "ee,mule,validations,aggregators,json,oauth,scripting,tracing,oauth2-provider,xml,wss,spring,java,avio-logger"
-            .split(","))
-        .map(s -> new MuleComponent(s, "*")).collect(Collectors.toList());
-
-    MuleNotificationProcessor muleNotificationProcessor1 = new MuleNotificationProcessor(null);
-    muleNotificationProcessor1.init((OpenTelemetryConnection) null,
-        new TraceLevelConfiguration(true, Collections.emptyList(),
-            Collections.singletonList(new MuleComponent("mule", "logger")), Collections.emptyList()));
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor1, configurationComponentLocator)
-            .getInterceptExclusions())
-                .as("Default with Trace level Exclusions")
-                .isNotEmpty()
-                .containsAll(expected)
-                .contains(new MuleComponent("mule", "logger"));
-  }
-
-  @Test
-  public void getInterceptInclusions() {
-    assertThat(new MessageProcessorTracingInterceptorFactory(new MuleNotificationProcessor(null),
-        configurationComponentLocator)
-            .getInterceptInclusions())
-                .as("Default Inclusion")
-                .isNotEmpty()
-                .containsOnly(new MuleComponent("mule", "flow-ref"),
-                    new MuleComponent("mule", "choice"),
-                    new MuleComponent("mule", "first-successful"),
-                    new MuleComponent("mule", "until-successful"),
-                    new MuleComponent("mule", "scatter-gather"),
-                    new MuleComponent("mule", "round-robin"),
-                    new MuleComponent("mule", "foreach"),
-                    new MuleComponent("mule", "parallel-foreach"),
-                    new MuleComponent("mule", "try"));
-  }
-
-  @Test
-  public void getInterceptInclusionsWithTraceLevelConfig() {
-    MuleNotificationProcessor muleNotificationProcessor1 = new MuleNotificationProcessor(null);
-    muleNotificationProcessor1.init((OpenTelemetryConnection) null,
-        new TraceLevelConfiguration(true, Collections.emptyList(),
-            Collections.emptyList(), Collections.singletonList(new MuleComponent("mule", "logger"))));
-    assertThat(
-        new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor1, configurationComponentLocator)
-            .getInterceptInclusions())
-                .as("Default with Trace level Inclusion")
-                .isNotEmpty()
-                .containsOnly(new MuleComponent("mule", "flow-ref"),
-                    new MuleComponent("mule", "logger"),
-                    new MuleComponent("mule", "choice"),
-                    new MuleComponent("mule", "first-successful"),
-                    new MuleComponent("mule", "until-successful"),
-                    new MuleComponent("mule", "scatter-gather"),
-                    new MuleComponent("mule", "round-robin"),
-                    new MuleComponent("mule", "foreach"),
-                    new MuleComponent("mule", "parallel-foreach"),
-                    new MuleComponent("mule", "try"));
   }
 
   @Test
@@ -351,8 +88,6 @@ public class MessageProcessorTracingInterceptorFactoryTest extends AbstractInter
     when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
     when(processor0.getParts()).thenReturn(Arrays.asList(part1));
 
-    TypedComponentIdentifier componentIdentifier = getComponentIdentifier(null, null);
-    when(processor0.getComponentIdentifier()).thenReturn(componentIdentifier);
     assertThat(
         new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
             .intercept(processor0))
@@ -361,9 +96,6 @@ public class MessageProcessorTracingInterceptorFactoryTest extends AbstractInter
     ComponentLocation flowRefLocation = Mockito.mock(ComponentLocation.class);
     when(flowRefLocation.getRootContainerName()).thenReturn("MyFlow");
     when(flowRefLocation.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
-
-    TypedComponentIdentifier flowRefIdentifier = getComponentIdentifier("mule", "flow-ref");
-    when(flowRefLocation.getComponentIdentifier()).thenReturn(flowRefIdentifier);
 
     LocationPart flowRefPart = mock(LocationPart.class);
     TypedComponentIdentifier identifier2 = mock(TypedComponentIdentifier.class);
@@ -381,8 +113,7 @@ public class MessageProcessorTracingInterceptorFactoryTest extends AbstractInter
 
   @Test
   public void interceptProcessor0AndDefaultIncluded() {
-    // When interception is not disabled, the processor 0 and default included
-    // processors must be intercepted
+    // When interception is not disabled, the processor 0 and others are intercepted
     // Default property value is false, so not setting it.
     // System.setProperty(MULE_OTEL_FIRST_PROCESSOR_INTERCEPTOR_ONLY, "false");
 
@@ -396,8 +127,6 @@ public class MessageProcessorTracingInterceptorFactoryTest extends AbstractInter
     when(part1.getPartIdentifier()).thenReturn(Optional.of(identifier));
     when(processor0.getParts()).thenReturn(Arrays.asList(part1));
 
-    TypedComponentIdentifier componentIdentifier = getComponentIdentifier(null, null);
-    when(processor0.getComponentIdentifier()).thenReturn(componentIdentifier);
     assertThat(
         new MessageProcessorTracingInterceptorFactory(muleNotificationProcessor, configurationComponentLocator)
             .intercept(processor0))
@@ -406,9 +135,6 @@ public class MessageProcessorTracingInterceptorFactoryTest extends AbstractInter
     ComponentLocation flowRefLocation = Mockito.mock(ComponentLocation.class);
     when(flowRefLocation.getRootContainerName()).thenReturn("MyFlow");
     when(flowRefLocation.getLocation()).thenReturn("MyFlow/processors/anything-but-0");
-
-    TypedComponentIdentifier flowRefIdentifier = getComponentIdentifier("mule", "flow-ref");
-    when(flowRefLocation.getComponentIdentifier()).thenReturn(flowRefIdentifier);
 
     LocationPart flowRefPart = mock(LocationPart.class);
     TypedComponentIdentifier identifier2 = mock(TypedComponentIdentifier.class);

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptorTest.java
@@ -44,6 +44,8 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     when(location.getLocation()).thenReturn("test-location");
     when(location.getRootContainerName()).thenReturn("test-flow-name");
     ComponentIdentifier ci = mock(ComponentIdentifier.class);
+    when(ci.getNamespace()).thenReturn("http");
+    when(ci.getName()).thenReturn("request");
     TypedComponentIdentifier tci = mock(TypedComponentIdentifier.class);
     when(tci.getIdentifier()).thenReturn(ci);
     when(location.getComponentIdentifier()).thenReturn(tci);
@@ -52,7 +54,7 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     MuleNotificationProcessor muleNotificationProcessor = mock(MuleNotificationProcessor.class);
     when(muleNotificationProcessor.getOpenTelemetryConnection()).thenReturn(connection);
     when(muleNotificationProcessor.hasConnection()).thenReturn(true);
-
+    when(muleNotificationProcessor.getInterceptorProcessorConfig()).thenReturn(new InterceptorProcessorConfig());
     ConfigurationComponentLocator configurationComponentLocator = mock(ConfigurationComponentLocator.class);
     ProcessorTracingInterceptor interceptor = new ProcessorTracingInterceptor(muleNotificationProcessor,
         configurationComponentLocator);
@@ -91,7 +93,8 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     when(location.getLocation()).thenReturn("test-location");
     when(location.getRootContainerName()).thenReturn("test-flow-name");
     ComponentIdentifier ci = mock(ComponentIdentifier.class);
-    when(ci.getName()).thenReturn("some");
+    when(ci.getNamespace()).thenReturn("http");
+    when(ci.getName()).thenReturn("request");
     TypedComponentIdentifier tci = mock(TypedComponentIdentifier.class);
     when(tci.getIdentifier()).thenReturn(ci);
     when(location.getComponentIdentifier()).thenReturn(tci);
@@ -100,7 +103,7 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     MuleNotificationProcessor muleNotificationProcessor = mock(MuleNotificationProcessor.class);
     when(muleNotificationProcessor.getOpenTelemetryConnection()).thenReturn(connection);
     when(muleNotificationProcessor.hasConnection()).thenReturn(true);
-
+    when(muleNotificationProcessor.getInterceptorProcessorConfig()).thenReturn(new InterceptorProcessorConfig());
     ConfigurationComponentLocator configurationComponentLocator = mock(ConfigurationComponentLocator.class);
     ProcessorTracingInterceptor interceptor = new ProcessorTracingInterceptor(muleNotificationProcessor,
         configurationComponentLocator);
@@ -136,7 +139,8 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     when(location.getLocation()).thenReturn("test-location");
     when(location.getRootContainerName()).thenReturn("test-flow-name");
     ComponentIdentifier ci = mock(ComponentIdentifier.class);
-    when(ci.getName()).thenReturn("some");
+    when(ci.getNamespace()).thenReturn("http");
+    when(ci.getName()).thenReturn("request");
     TypedComponentIdentifier tci = mock(TypedComponentIdentifier.class);
     when(tci.getIdentifier()).thenReturn(ci);
     when(location.getComponentIdentifier()).thenReturn(tci);
@@ -149,6 +153,7 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     when(muleNotificationProcessor.getOpenTelemetryConnection()).thenReturn(connection);
     when(muleNotificationProcessor.hasConnection()).thenReturn(true);
     when(muleNotificationProcessor.getProcessorComponent(ci)).thenReturn(processorComponent);
+    when(muleNotificationProcessor.getInterceptorProcessorConfig()).thenReturn(new InterceptorProcessorConfig());
 
     // Component not found
     ConfigurationComponentLocator configurationComponentLocator = mock(ConfigurationComponentLocator.class);
@@ -203,7 +208,7 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     when(muleNotificationProcessor.getOpenTelemetryConnection()).thenReturn(connection);
     when(muleNotificationProcessor.hasConnection()).thenReturn(true);
     when(muleNotificationProcessor.getProcessorComponent(ci)).thenReturn(processorComponent);
-
+    when(muleNotificationProcessor.getInterceptorProcessorConfig()).thenReturn(new InterceptorProcessorConfig());
     Component component = mock(Component.class);
     ConfigurationComponentLocator configurationComponentLocator = mock(ConfigurationComponentLocator.class);
     when(configurationComponentLocator.find(any(Location.class))).thenReturn(Optional.of(component));
@@ -251,7 +256,8 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     when(location.getLocation()).thenReturn("test-location");
     when(location.getRootContainerName()).thenReturn("test-flow-name");
     ComponentIdentifier ci = mock(ComponentIdentifier.class);
-    when(ci.getName()).thenReturn("something");
+    when(ci.getNamespace()).thenReturn("http");
+    when(ci.getName()).thenReturn("request");
     TypedComponentIdentifier tci = mock(TypedComponentIdentifier.class);
     when(tci.getIdentifier()).thenReturn(ci);
     when(location.getComponentIdentifier()).thenReturn(tci);
@@ -271,7 +277,7 @@ public class ProcessorTracingInterceptorTest extends AbstractInternalTest {
     when(muleNotificationProcessor.hasConnection()).thenReturn(true);
     when(muleNotificationProcessor.getProcessorComponent(any(ComponentIdentifier.class)))
         .thenReturn(processorComponent);
-
+    when(muleNotificationProcessor.getInterceptorProcessorConfig()).thenReturn(new InterceptorProcessorConfig());
     Component component = mock(Component.class);
     ConfigurationComponentLocator configurationComponentLocator = mock(ConfigurationComponentLocator.class);
     when(configurationComponentLocator.find(any(Location.class))).thenReturn(Optional.of(component));

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessorTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleNotificationProcessorTest.java
@@ -37,6 +37,7 @@ public class MuleNotificationProcessorTest extends AbstractProcessorComponentTes
     MuleNotificationProcessor notificationProcessor = new MuleNotificationProcessor(configurationComponentLocator);
     notificationProcessor.init(connection, new TraceLevelConfiguration(false, Collections.emptyList()));
     notificationProcessor.handleProcessorStartEvent(notification);
+    verify(connection).isTurnOffTracing();
     verifyNoMoreInteractions(connection);
   }
 
@@ -61,7 +62,7 @@ public class MuleNotificationProcessorTest extends AbstractProcessorComponentTes
 
     notificationProcessor.init(connection, traceLevelConfiguration);
     notificationProcessor.handleProcessorStartEvent(notification);
-
+    verify(connection).isTurnOffTracing();
     verifyNoMoreInteractions(connection);
   }
 
@@ -85,7 +86,7 @@ public class MuleNotificationProcessorTest extends AbstractProcessorComponentTes
 
     notificationProcessor.init(connection, traceLevelConfiguration);
     notificationProcessor.handleProcessorStartEvent(notification);
-
+    verify(connection).isTurnOffTracing();
     verifyNoMoreInteractions(connection);
   }
 
@@ -105,6 +106,7 @@ public class MuleNotificationProcessorTest extends AbstractProcessorComponentTes
     MuleNotificationProcessor notificationProcessor = new MuleNotificationProcessor(configurationComponentLocator);
     notificationProcessor.init(connection, new TraceLevelConfiguration(false, Collections.emptyList()));
     notificationProcessor.handleProcessorEndEvent(notification);
+    verify(connection).isTurnOffTracing();
     verifyNoMoreInteractions(connection);
   }
 


### PR DESCRIPTION
This PR limits the default component interception to what is needed for context propagation. See the documentation updates in this PR for a list of operations intercepted and how to adjust those if needed.

Resolves #235 