### PR TITLE
feat: reuse attributekey instances to reduce memory usage

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/api/sdk/SemanticAttributes.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/api/sdk/SemanticAttributes.java
@@ -1,6 +1,7 @@
 package com.avioconsulting.mule.opentelemetry.api.sdk;
 
 import io.opentelemetry.api.common.AttributeKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 /**
  * Defines the attribute keys to be used when capturing mule related span
@@ -11,122 +12,136 @@ public final class SemanticAttributes {
   }
 
   /**
+   * Override {@link io.opentelemetry.semconv.SemanticAttributes#SERVER_PORT} type
+   * from Long to String
+   */
+  public static final AttributeKey<String> SERVER_PORT_SA = stringKey("server.port");
+  /**
+   * Override
+   * {@link io.opentelemetry.semconv.SemanticAttributes#HTTP_RESPONSE_STATUS_CODE}
+   * type from Long to String
+   */
+  public static final AttributeKey<String> HTTP_RESPONSE_STATUS_CODE_SA = stringKey("http.response.status_code");
+
+  public static final AttributeKey<String> HTTP_RESPONSE_HEADER_CONTENT_LENGTH = stringKey(
+      "http.response.header.content-length");
+  public static final AttributeKey<String> MULE_APP_PROCESSOR_FLOW_REF_NAME = stringKey(
+      "mule.app.processor.flowRef.name");
+  /**
    * Absolute path to mule installation.
    */
-  public static final AttributeKey<String> MULE_HOME = AttributeKey.stringKey("mule.home");
+  public static final AttributeKey<String> MULE_HOME = stringKey("mule.home");
 
   /**
    * Mule Correlation Id for the current event.
    */
-  public static final AttributeKey<String> MULE_CORRELATION_ID = AttributeKey.stringKey("mule.correlationId");
+  public static final AttributeKey<String> MULE_CORRELATION_ID = stringKey("mule.correlationId");
 
   /**
    * Mule Server Id that is processing current request.
    */
-  public static final AttributeKey<String> MULE_SERVER_ID = AttributeKey.stringKey("mule.serverId");
-  public static final AttributeKey<String> MULE_CSORGANIZATION_ID = AttributeKey.stringKey("mule.csOrganization.id");
+  public static final AttributeKey<String> MULE_SERVER_ID = stringKey("mule.serverId");
+  public static final AttributeKey<String> MULE_CSORGANIZATION_ID = stringKey("mule.csOrganization.id");
 
   /**
    * Most of the Mule users are familiar with organization id instead of
    * CSORGANIZATION ID.
    */
-  public static final AttributeKey<String> MULE_ORGANIZATION_ID = AttributeKey.stringKey("mule.organization.id");
+  public static final AttributeKey<String> MULE_ORGANIZATION_ID = stringKey("mule.organization.id");
 
   /**
    * Mule Environment ID. See <a src=
    * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
    */
-  public static final AttributeKey<String> MULE_ENVIRONMENT_ID = AttributeKey.stringKey("mule.environment.id");
+  public static final AttributeKey<String> MULE_ENVIRONMENT_ID = stringKey("mule.environment.id");
 
   /**
    * Mule Environment Type - eg. sandbox or production. See <a src=
    * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
    */
-  public static final AttributeKey<String> MULE_ENVIRONMENT_TYPE = AttributeKey.stringKey("mule.environment.type");
+  public static final AttributeKey<String> MULE_ENVIRONMENT_TYPE = stringKey("mule.environment.type");
 
   /**
    * AWS Region in which Application is deployed in. See <a src=
    * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
    */
-  public static final AttributeKey<String> MULE_ENVIRONMENT_AWS_REGION = AttributeKey
-      .stringKey("mule.environment.awsRegion");
+  public static final AttributeKey<String> MULE_ENVIRONMENT_AWS_REGION = stringKey("mule.environment.awsRegion");
 
   /**
    * Mule CloudHub Worker id that is processing current request. See <a src=
    * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
    */
-  public static final AttributeKey<String> MULE_WORKER_ID = AttributeKey.stringKey("mule.worker.id");
+  public static final AttributeKey<String> MULE_WORKER_ID = stringKey("mule.worker.id");
 
   /**
    * Mule Processor Name. For example `http:request` processor will have `request`
    * as processor name.
    */
-  public static final AttributeKey<String> MULE_APP_PROCESSOR_NAME = AttributeKey
-      .stringKey("mule.app.processor.name");
+  public static final AttributeKey<String> MULE_APP_PROCESSOR_NAME = stringKey("mule.app.processor.name");
 
   /**
    * XML Namespace of the Mule processor. For example `http:request` processor
    * will have `http` as processor namespace.
    */
-  public static final AttributeKey<String> MULE_APP_PROCESSOR_NAMESPACE = AttributeKey
-      .stringKey("mule.app.processor.namespace");
+  public static final AttributeKey<String> MULE_APP_PROCESSOR_NAMESPACE = stringKey("mule.app.processor.namespace");
 
   /**
    * Documented name of the processor. Usually, the value of `doc:name` attribute
    * on processor.
    */
-  public static final AttributeKey<String> MULE_APP_PROCESSOR_DOC_NAME = AttributeKey
-      .stringKey("mule.app.processor.docName");
+  public static final AttributeKey<String> MULE_APP_PROCESSOR_DOC_NAME = stringKey("mule.app.processor.docName");
 
   /**
    * Name of the configuration element, if exists on the processor. Usually, the
    * value of `configRef` attribute on processor.
    */
-  public static final AttributeKey<String> MULE_APP_PROCESSOR_CONFIG_REF = AttributeKey
-      .stringKey("mule.app.processor.configRef");
-  public static final AttributeKey<String> MULE_APP_FLOW_NAME = AttributeKey.stringKey("mule.app.flow.name");
+  public static final AttributeKey<String> MULE_APP_PROCESSOR_CONFIG_REF = stringKey("mule.app.processor.configRef");
+  public static final AttributeKey<String> MULE_APP_FLOW_NAME = stringKey("mule.app.flow.name");
 
   /**
    * Name of the configuration element used by the flow source component. Usually,
    * the value of `configRef` attribute on source.
    */
-  public static final AttributeKey<String> MULE_APP_FLOW_SOURCE_CONFIG_REF = AttributeKey
-      .stringKey("mule.app.flow.source.configRef");
+  public static final AttributeKey<String> MULE_APP_FLOW_SOURCE_CONFIG_REF = stringKey(
+      "mule.app.flow.source.configRef");
   /**
    * XML Namespace of the Source component. For example `http:listener` source
    * will have `http` as the namespace.
    */
-  public static final AttributeKey<String> MULE_APP_FLOW_SOURCE_NAMESPACE = AttributeKey
-      .stringKey("mule.app.flow.source.namespace");
+  public static final AttributeKey<String> MULE_APP_FLOW_SOURCE_NAMESPACE = stringKey(
+      "mule.app.flow.source.namespace");
 
   /**
    * Mule Flow Source's Name. For example `http:listener` source will have
    * `listener` as the name.
    */
-  public static final AttributeKey<String> MULE_APP_FLOW_SOURCE_NAME = AttributeKey
-      .stringKey("mule.app.flow.source.name");
+  public static final AttributeKey<String> MULE_APP_FLOW_SOURCE_NAME = stringKey("mule.app.flow.source.name");
 
   /**
    * Application Name. See <a src=
    * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
    */
-  public static final AttributeKey<String> MULE_APP_DOMAIN = AttributeKey.stringKey("mule.app.domain");
+  public static final AttributeKey<String> MULE_APP_DOMAIN = stringKey("mule.app.domain");
   /**
    * Full DNS of application. See <a src=
    * "https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties">CloudHub-Reserved-Properties</a>.
    */
-  public static final AttributeKey<String> MULE_APP_FULL_DOMAIN = AttributeKey.stringKey("mule.app.fullDomain");
+  public static final AttributeKey<String> MULE_APP_FULL_DOMAIN = stringKey("mule.app.fullDomain");
 
   /**
    * Key to define datasource name for db connections
    */
-  public static final AttributeKey<String> DB_DATASOURCE = AttributeKey.stringKey("db.datasource");
+  public static final AttributeKey<String> DB_DATASOURCE = stringKey("db.datasource");
 
   /**
    * Key to capture Error types
    */
-  public static final AttributeKey<String> ERROR_TYPE = AttributeKey.stringKey("error.type");
+  public static final AttributeKey<String> ERROR_TYPE = stringKey("error.type");
 
-  public static final AttributeKey<String> MULE_APP_SCOPE_SUBFLOW_NAME = AttributeKey
-      .stringKey("mule.app.scope.subflow.name");
+  public static final AttributeKey<String> MULE_APP_SCOPE_SUBFLOW_NAME = stringKey("mule.app.scope.subflow.name");
+
+  public static final AttributeKey<String> WSC_CONSUMER_OPERATION = stringKey("mule.wsc.consumer.operation");
+  public static final AttributeKey<String> WSC_CONFIG_SERVICE = stringKey("mule.wsc.config.service");
+  public static final AttributeKey<String> WSC_CONFIG_PORT = stringKey("mule.wsc.config.port");
+  public static final AttributeKey<String> WSC_CONFIG_ADDRESS = stringKey("mule.wsc.config.address");
 }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/AttributesKeyCache.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/AttributesKeyCache.java
@@ -1,0 +1,60 @@
+package com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk;
+
+import com.avioconsulting.mule.opentelemetry.api.sdk.SemanticAttributes;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.ServerAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.UserAgentAttributes;
+import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AttributesKeyCache {
+
+  private static final Map<String, AttributeKey<String>> attributeKeyMap = new HashMap<>();
+
+  public AttributesKeyCache() {
+  }
+
+  static {
+    mapFields(io.opentelemetry.semconv.SemanticAttributes.class.getDeclaredFields());
+    mapFields(HttpAttributes.class.getDeclaredFields());
+    mapFields(UrlAttributes.class.getDeclaredFields());
+    mapFields(UserAgentAttributes.class.getDeclaredFields());
+    mapFields(ServerAttributes.class.getDeclaredFields());
+    mapFields(DbIncubatingAttributes.class.getDeclaredFields());
+    mapFields(MessagingIncubatingAttributes.class.getDeclaredFields());
+    mapFields(SemanticAttributes.class.getDeclaredFields());
+  }
+
+  private static void mapFields(Field[] declaredFields) {
+    for (Field declaredField : declaredFields) {
+      if (declaredField.getType().isAssignableFrom(AttributeKey.class)) {
+        try {
+          AttributeKey<String> key = (AttributeKey<String>) declaredField.get(null);
+          attributeKeyMap.put(key.toString(), key);
+        } catch (IllegalAccessException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+  }
+
+  private final Object lock = new Object();
+
+  public AttributeKey<String> getAttributeKey(String keyString) {
+    AttributeKey<String> key = attributeKeyMap.get(keyString);
+    if (key == null) {
+      key = AttributeKey.stringKey(keyString);
+      synchronized (lock) {
+        attributeKeyMap.put(keyString, key);
+      }
+    }
+    return key;
+  }
+
+}

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/HttpProcessorComponent.java
@@ -1,5 +1,6 @@
 package com.avioconsulting.mule.opentelemetry.internal.processor;
 
+import com.avioconsulting.mule.opentelemetry.api.sdk.SemanticAttributes;
 import com.avioconsulting.mule.opentelemetry.api.traces.TraceComponent;
 import com.avioconsulting.mule.opentelemetry.internal.connection.TraceContextHandler;
 import com.avioconsulting.mule.opentelemetry.internal.processor.util.HttpSpanUtil;
@@ -28,6 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.avioconsulting.mule.opentelemetry.api.sdk.SemanticAttributes.HTTP_RESPONSE_STATUS_CODE_SA;
+import static com.avioconsulting.mule.opentelemetry.api.sdk.SemanticAttributes.SERVER_PORT_SA;
 import static io.opentelemetry.semconv.HttpAttributes.*;
 import static io.opentelemetry.semconv.ServerAttributes.*;
 import static io.opentelemetry.semconv.UrlAttributes.*;
@@ -107,9 +110,9 @@ public class HttpProcessorComponent extends AbstractProcessorComponent {
     // include the HTTP Response attributes.
     HttpResponseAttributes attributes = responseAttributes.getValue();
     Map<String, String> tags = new HashMap<>();
-    tags.put(HTTP_RESPONSE_STATUS_CODE.getKey(), Integer.toString(attributes.getStatusCode()));
+    tags.put(HTTP_RESPONSE_STATUS_CODE_SA.getKey(), Integer.toString(attributes.getStatusCode()));
     endTraceComponent.withStatsCode(getSpanStatus(false, attributes.getStatusCode()));
-    tags.put("http.response.header.content-length",
+    tags.put(SemanticAttributes.HTTP_RESPONSE_HEADER_CONTENT_LENGTH.getKey(),
         attributes.getHeaders().get("content-length"));
     if (endTraceComponent.getTags() != null)
       tags.putAll(endTraceComponent.getTags());
@@ -164,7 +167,7 @@ public class HttpProcessorComponent extends AbstractProcessorComponent {
     if (!connectionParameters.isEmpty()) {
       tags.put(URL_SCHEME.getKey(), connectionParameters.getOrDefault("protocol", "").toLowerCase());
       tags.put(ServerAttributes.SERVER_ADDRESS.getKey(), connectionParameters.getOrDefault("host", ""));
-      tags.put(SERVER_PORT.getKey(), connectionParameters.getOrDefault("port", ""));
+      tags.put(SERVER_PORT_SA.getKey(), connectionParameters.getOrDefault("port", ""));
     }
     Map<String, String> configParameters = componentWrapper.getConfigParameters();
     if (!configParameters.isEmpty()) {
@@ -213,7 +216,7 @@ public class HttpProcessorComponent extends AbstractProcessorComponent {
           statusCode = TypedValue.unwrap(httpStatus).toString();
         }
         TraceComponent traceComponent = getTraceComponentBuilderFor(notification);
-        traceComponent.withTags(singletonMap(HTTP_RESPONSE_STATUS_CODE.getKey(), statusCode));
+        traceComponent.withTags(singletonMap(HTTP_RESPONSE_STATUS_CODE_SA.getKey(), statusCode));
         traceComponent.withStatsCode(getSpanStatus(true, Integer.parseInt(statusCode)));
         return traceComponent;
       }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleCoreProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/MuleCoreProcessorComponent.java
@@ -9,6 +9,8 @@ import org.mule.runtime.api.notification.EnrichedServerNotification;
 
 import java.util.*;
 
+import static com.avioconsulting.mule.opentelemetry.api.sdk.SemanticAttributes.MULE_APP_PROCESSOR_FLOW_REF_NAME;
+
 /**
  * This processor handles any specific operations or sources from Mule Core
  * namespace that are needed for overall tracing.
@@ -58,7 +60,8 @@ public class MuleCoreProcessorComponent extends AbstractProcessorComponent {
     ComponentWrapper componentWrapper = new ComponentWrapper(component,
         configurationComponentLocator);
     if (ComponentsUtil.isFlowRef(component.getLocation())) {
-      tags.put("mule.app.processor.flowRef.name", componentWrapper.getParameter("name"));
+      tags.put(MULE_APP_PROCESSOR_FLOW_REF_NAME.getKey(),
+          componentWrapper.getParameter("name"));
     }
     return tags;
   }
@@ -69,7 +72,8 @@ public class MuleCoreProcessorComponent extends AbstractProcessorComponent {
     ComponentWrapper componentWrapper = new ComponentWrapper(notification.getComponent(),
         configurationComponentLocator);
     if (ComponentsUtil.isFlowRef(notification.getComponent().getLocation())) {
-      endTraceComponent.getTags().put("mule.app.processor.flowRef.name", componentWrapper.getParameter("name"));
+      endTraceComponent.getTags().put(MULE_APP_PROCESSOR_FLOW_REF_NAME.getKey(),
+          componentWrapper.getParameter("name"));
     }
     return endTraceComponent;
   }

--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/WSCProcessorComponent.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/WSCProcessorComponent.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.avioconsulting.mule.opentelemetry.api.sdk.SemanticAttributes.*;
+
 public class WSCProcessorComponent extends AbstractProcessorComponent {
   @Override
   protected String getNamespace() {
@@ -41,12 +43,12 @@ public class WSCProcessorComponent extends AbstractProcessorComponent {
   protected <A> Map<String, String> getAttributes(Component component, TypedValue<A> attributes) {
     ComponentWrapper componentWrapper = new ComponentWrapper(component, configurationComponentLocator);
     Map<String, String> tags = new HashMap<>();
-    tags.put("mule.wsc.consumer.operation", componentWrapper.getParameter("operation"));
+    tags.put(WSC_CONSUMER_OPERATION.getKey(), componentWrapper.getParameter("operation"));
     Map<String, String> configConnectionParameters = componentWrapper.getConfigConnectionParameters();
-    tags.put("mule.wsc.config.service", configConnectionParameters.get("service"));
-    tags.put("mule.wsc.config.port", configConnectionParameters.get("port"));
+    tags.put(WSC_CONFIG_SERVICE.getKey(), configConnectionParameters.get("service"));
+    tags.put(WSC_CONFIG_PORT.getKey(), configConnectionParameters.get("port"));
     if (configConnectionParameters.containsKey("address")) {
-      tags.put("mule.wsc.config.address", configConnectionParameters.get("address"));
+      tags.put(WSC_CONFIG_ADDRESS.getKey(), configConnectionParameters.get("address"));
     }
     return tags;
   }


### PR DESCRIPTION
Instead of creating a new instance of AttributeKey for each attribute string key, reuse cached instances as keys.

OpenTelemetry SDK uses instances of `AttributeKey<T>` as a typed-key for all trace attributes. As the module uses string-based keys, SDK was creating a new instance of `AttributeKey<T>` for every attribute added, even though the string keys were same.

Below is the comparison of object creations during a test -

Without this fix - 
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/36436483-d488-41ed-bd70-fe1cc2fa0763" />

Same test with this fix -
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/f6f2477d-945e-4574-add6-7dfb5a9e1b61" />


