### PR TITLE
fix: http route internal tag value

### DIFF
--- a/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/FlowSpan.java
+++ b/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/FlowSpan.java
@@ -147,9 +147,12 @@ public class FlowSpan implements Serializable {
       if (rootSpanName.endsWith("/*")) { // Wildcard listener for HTTP APIKit Router
         String apiKitRoutePath = apiKitRoutePath(traceComponent.getTags());
         String spanName = getRootSpanName().replace("/*", apiKitRoutePath);
+        setRootSpanName(spanName);
         getSpan().updateName(spanName);
         // HTTP Span Name of the format '{METHOD} {ROUTE}'
-        getSpan().setAttribute(HTTP_ROUTE, spanName.substring(spanName.lastIndexOf(" ") + 1));
+        String httpRoute = spanName.substring(spanName.lastIndexOf(" ") + 1);
+        getTags().put(HTTP_ROUTE.getKey(), httpRoute);
+        getSpan().setAttribute(HTTP_ROUTE, httpRoute);
       }
     }
   }

--- a/src/test/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStoreTest.java
+++ b/src/test/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStoreTest.java
@@ -5,6 +5,7 @@ import com.avioconsulting.mule.opentelemetry.api.config.OpenTelemetryResource;
 import com.avioconsulting.mule.opentelemetry.api.config.exporter.LoggingExporter;
 import com.avioconsulting.mule.opentelemetry.api.config.exporter.OpenTelemetryExporter;
 import com.avioconsulting.mule.opentelemetry.api.sdk.SemanticAttributes;
+import com.avioconsulting.mule.opentelemetry.api.store.SpanMeta;
 import com.avioconsulting.mule.opentelemetry.api.store.TransactionMeta;
 import com.avioconsulting.mule.opentelemetry.api.traces.TraceComponent;
 import com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryConfigWrapper;
@@ -27,6 +28,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class InMemoryTransactionStoreTest {
@@ -36,6 +38,7 @@ public class InMemoryTransactionStoreTest {
       .fromSingleComponent(TEST_1_FLOW_FLOW_REF);
   public static final String TEST_1_FLOW = "test-1-flow";
   OpenTelemetryConnection connection;
+  private Tracer tracer;
 
   @Before
   public void setUp() {
@@ -50,12 +53,14 @@ public class InMemoryTransactionStoreTest {
     OpenTelemetryConfigWrapper wrapper = new OpenTelemetryConfigWrapper(configuration);
     connection = OpenTelemetryConnection.getInstance(wrapper);
 
-    Tracer tracer = GlobalOpenTelemetry.get().getTracer("test", "v1");
+    this.tracer = GlobalOpenTelemetry.get().getTracer("test", "v1");
     Instant startTimestamp = Instant.now();
     SpanBuilder spanBuilder = tracer.spanBuilder("test-transaction")
         .setSpanKind(SpanKind.SERVER)
         .setStartTimestamp(startTimestamp);
-    TraceComponent traceComponent = TraceComponent.of("test-1").withTransactionId("test-1")
+    TraceComponent traceComponent = TraceComponent.of("test-1")
+        .withTransactionId("test-1")
+        .withSpanName("GET /api/*")
         .withStartTime(startTimestamp)
         .withLocation(TEST_1_FLOW_FLOW_REF)
         .withTags(new HashMap<>());
@@ -79,8 +84,69 @@ public class InMemoryTransactionStoreTest {
 
     TransactionMeta transactionMeta = connection.getTransactionStore().endTransaction(endTraceComponent, (span -> {
     }));
-    Assertions.assertThat(transactionMeta).isNotNull()
+    assertThat(transactionMeta).isNotNull()
         .extracting("tags", InstanceOfAssertFactories.map(String.class, String.class))
         .containsEntry("TEST_TAG_KEY", "test-tag-value");
+  }
+
+  private void processAPIKitRouterComponent() {
+    String name = "router:router";
+    TraceComponent apikitFlow = TraceComponent.of(name)
+        .withTransactionId("test-1")
+        .withSpanName(name)
+        .withStartTime(Instant.now().minusSeconds(10))
+        .withLocation(TEST_1_FLOW + "processors/0")
+        .withEventContextId("test-1-context-id")
+        .withEndTime(Instant.now())
+        .withTags(new HashMap<>());
+    apikitFlow.getTags().put(SemanticAttributes.MULE_APP_PROCESSOR_NAMESPACE.getKey(), "apikit");
+    apikitFlow.getTags().put(SemanticAttributes.MULE_APP_PROCESSOR_NAME.getKey(), "router");
+    apikitFlow.getTags().put(SemanticAttributes.MULE_APP_PROCESSOR_CONFIG_REF.getKey(), "order-exp-config");
+    SpanBuilder spanBuilder = tracer.spanBuilder(apikitFlow.getSpanName())
+        .setSpanKind(SpanKind.INTERNAL)
+        .setStartTimestamp(apikitFlow.getStartTime());
+    connection.getTransactionStore().addProcessorSpan(null, apikitFlow, spanBuilder);
+  }
+
+  @Test
+  public void resetting_span_name_is_updated_in_transaction() {
+    // Add APIKit router component to set the apikit config name on root transaction
+    processAPIKitRouterComponent();
+
+    // Process an APIKit Flow span to trigger http route renaming
+    String name = "get:\\orders\\(orderId):order-exp-config";
+    TraceComponent apikitFlow = TraceComponent.of(name)
+        .withTransactionId("test-1")
+        .withSpanName(name)
+        .withStartTime(Instant.now().minusSeconds(10))
+        .withLocation(name)
+        .withEventContextId("test-1-context-id")
+        .withEndTime(Instant.now())
+        .withTags(new HashMap<>());
+    apikitFlow.getTags().put(SemanticAttributes.MULE_APP_PROCESSOR_NAMESPACE.getKey(), "mule");
+    apikitFlow.getTags().put(SemanticAttributes.MULE_APP_PROCESSOR_NAME.getKey(), "flow");
+    apikitFlow.getTags().put(SemanticAttributes.MULE_APP_FLOW_NAME.getKey(), name);
+    SpanBuilder spanBuilder = tracer.spanBuilder(apikitFlow.getSpanName())
+        .setSpanKind(SpanKind.INTERNAL)
+        .setStartTimestamp(apikitFlow.getStartTime());
+    SpanMeta spanMeta = connection.getTransactionStore().addProcessorSpan(null, apikitFlow, spanBuilder);
+    assertThat(spanMeta).isNotNull();
+
+    // There is no method exposed for checking transaction tags.
+    // End transaction method returns the transaction meta, so end the root
+    // transaction to verify tags.
+
+    TraceComponent traceComponent = TraceComponent.of(TEST_1_FLOW)
+        .withTransactionId("test-1")
+        .withSpanName("GET /api/*")
+        .withEndTime(Instant.now())
+        .withLocation(TEST_1_FLOW_FLOW_REF)
+        .withTags(new HashMap<>());
+    TransactionMeta transactionMeta = connection.getTransactionStore().endTransaction(traceComponent, span -> {
+    });
+    assertThat(transactionMeta).isNotNull()
+        .extracting("tags", InstanceOfAssertFactories.map(String.class, String.class))
+        .containsEntry("http.route", "/api/orders/{orderId}");
+
   }
 }


### PR DESCRIPTION
When updating span name and http route for exportable data, the internal tags were missing the updates. 