### PR TITLE
chore: jreleaser to comment on released issues

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -31,7 +31,16 @@ release:
     releaseName: '{{tagName}}'
     skipTag: false
     milestone:
-      close: false
+      close: true
+      name: '{{tagName}}'
+    issues:
+      enabled: true
+      comment: '🎉 This issue has been resolved in `{{tagName}}` ([Release Notes]({{releaseNotesUrl}}))'
+      applyMilestone: ALWAYS
+      label:
+        name: released
+        color: '#008000'
+        description: Issue has been released
     changelog:
       skipMergeCommits: true
       formatted: ALWAYS


### PR DESCRIPTION
When released, JReleaser will add comments like below to all issues and PRs included in the release -

<img width="424" alt="image" src="https://github.com/user-attachments/assets/73b600c9-d79d-41cc-a261-df864ef8b260" />