### PR TITLE
fix: consistent exporter endpoint format for http and grpc

### DIFF
--- a/mule-module/src/docs/asciidoc/module-config.adoc
+++ b/mule-module/src/docs/asciidoc/module-config.adoc
@@ -251,10 +251,7 @@ NOTE: Configured exporter is used for all supported signals.
 ==== OTLP Exporter
 Extension contains all dependencies needed to send supported signals to an OpenTelemetry Collector endpoint.
 
-NOTE: When configuring the OTLP Exporter with *HTTP Protobuf protocol*, OpenTelemetry collector endpoint *must be set to the base endpoint* of OTEL collector. The module will build signal-specific endpoints such as `{collectorEndpoint}/traces` based on OpenTelemetry specification guidelines.
-For example, if opentelemetry collector is listening on localhost:4317, then set `collectorEndpoint=http://localhost:4317/v1` and *NOT* [.line-through]#`collectorEndpoint=http://localhost:4317/v1/traces`#.
-
-NOTE: When configuring the OTLP Exporter with *GRPC protocol*, OpenTelemetry collector endpoint *must be set to the base endpoint* of OTEL collector. For example, if opentelemetry collector is listening on localhost:4317, then set `collectorEndpoint=http://localhost:4317` and *NOT* [.line-through]#`collectorEndpoint=http://localhost:4317/v1`#.
+NOTE: For example, `http(s)://localhost:4318` when configuring the OTLP Exporter with *HTTP Protobuf protocol*, OR `http(s)://localhost:4317` when using *GRPC protocol*.
 
 image::module-otel-exporter-config.png[alt="OTEL OTLP Exporter configuration"]
 

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporter.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporter.java
@@ -35,9 +35,10 @@ public class OtlpExporter extends AbstractExporter {
   @Optional
   @Summary(value = "The OTLP traces, metrics, and logs endpoint to connect to. Must be a URL with a scheme of either http or https based on the use of TLS."
       +
-      "GRPC Protocol may have URL like http://localhost:4317 and HTTP_PROTOBUF be like http://localhost:4317/v1.")
+      "GRPC Protocol may have URL like http://localhost:4317 and HTTP_PROTOBUF be like http://localhost:4318.")
   @Example(value = "http://localhost:4317")
   private String collectorEndpoint;
+  private String computedCollectorEndpoint;
 
   @Parameter
   @Optional(defaultValue = "GRPC")
@@ -87,7 +88,15 @@ public class OtlpExporter extends AbstractExporter {
   }
 
   public String getCollectorEndpoint() {
-    return collectorEndpoint;
+    if (computedCollectorEndpoint != null) {
+      return computedCollectorEndpoint;
+    }
+    if (Protocol.HTTP_PROTOBUF.equals(protocol) && !collectorEndpoint.toLowerCase().endsWith("/v1")) {
+      computedCollectorEndpoint = collectorEndpoint + "/v1";
+    } else {
+      computedCollectorEndpoint = collectorEndpoint;
+    }
+    return computedCollectorEndpoint;
   }
 
   public String getEndpointCertPath() {

--- a/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporterTest.java
+++ b/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/api/config/exporter/OtlpExporterTest.java
@@ -31,6 +31,24 @@ public class OtlpExporterTest {
   }
 
   @Test
+  public void verifyHTTPProtobufEndpointIsAmended() {
+    java.util.List<Header> headers = new java.util.ArrayList<>();
+    headers.add(new Header("test", "value"));
+    headers.add(new Header("test2", "value2"));
+    OtlpExporter otlpExporter = new OtlpExporter("http://localhost", OtlpExporter.Protocol.HTTP_PROTOBUF,
+        OtlpExporter.OtlpRequestCompression.GZIP, headers);
+    assertThat(otlpExporter.getExporterProperties())
+        .containsEntry(OTEL_TRACES_EXPORTER_KEY, OTLP)
+        .containsEntry(OTEL_EXPORTER_OTLP_COMPRESSION, OtlpExporter.OtlpRequestCompression.GZIP.getValue())
+        .containsEntry(OTEL_EXPORTER_OTLP_PROTOCOL, Protocol.HTTP_PROTOBUF.getValue())
+        .containsEntry(OTEL_EXPORTER_OTLP_HEADERS, "test=value,test2=value2")
+        .containsEntry(OTEL_EXPORTER_OTLP_ENDPOINT, "http://localhost/v1")
+        .containsEntry(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, "http://localhost/v1/traces")
+        .containsEntry(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, "http://localhost/v1/logs")
+        .containsEntry(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, "http://localhost/v1/metrics");
+  }
+
+  @Test
   public void verifyNoCompressionSet() {
     OtlpExporter otlpExporter = new OtlpExporter("http://localhost", OtlpExporter.Protocol.HTTP_PROTOBUF,
         OtlpExporter.OtlpRequestCompression.NONE, Collections.emptyList());


### PR DESCRIPTION
When using OTLP Exporter with HTTP Protobuf protocol, the endpoint required adding /v1 to it. This change makes it consitent with GRPC and allows (with backward compatibility) to set it without explicit /v1.