### PR TITLE
fix: capture only process id and executable path

### DIFF
--- a/mule-module/src/docs/asciidoc/module-config.adoc
+++ b/mule-module/src/docs/asciidoc/module-config.adoc
@@ -105,7 +105,6 @@ Extension uses the OpenTelemetry SDK's https://github.com/open-telemetry/opentel
     "host.name": "ac0098.local",
     "os.description": "Mac OS X 10.16",
     "os.type": "darwin",
-    "process.command_line": "/Applications/AnypointStudio.app/Contents/Eclipse/plugins/org.mule.tooling.jdk.v8.macosx.x86_64_1.1.1/Contents/Home/jre:bin:java -Dmule.home=/Applications/AnypointStudio.app/Contents/....d=1 -Dwrapper.lang.domain=wrapper -Dwrapper.lang.folder=../lang",
     "process.executable.path": "/Applications/AnypointStudio.app/Contents/Eclipse/plugins/org.mule.tooling.jdk.v8.macosx.x86_64_1.1.1/Contents/Home/jre:bin:java",
     "process.pid": "9778",
     "process.runtime.description": "AdoptOpenJDK OpenJDK 64-Bit Server VM 25.282-b08",

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
@@ -97,7 +97,7 @@ public class OpenTelemetryConnection implements TraceContextHandler,
         configMap.putAll(openTelemetryConfigWrapper.getSpanProcessorConfiguration().getConfigMap());
       }
       // Disable the resource providers that are handled by
-      // MuleAppHostResourceProvider
+      // MuleAppHostResourceProvider or MuleResourceProvider
       configMap.put("otel.java.disabled.resource.providers",
           "io.opentelemetry.instrumentation.resources.HostResourceProvider," +
               "io.opentelemetry.instrumentation.resources.ContainerResourceProvider," +

--- a/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResourceProviderTest.java
+++ b/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/opentelemetry/sdk/MuleResourceProviderTest.java
@@ -3,6 +3,7 @@ package com.avioconsulting.mule.opentelemetry.internal.opentelemetry.sdk;
 import com.avioconsulting.mule.opentelemetry.internal.AbstractInternalTest;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -41,7 +42,9 @@ public class MuleResourceProviderTest extends AbstractInternalTest {
         .containsEntry(MULE_WORKER_ID, "MULE_WORKER_ID")
         .containsEntry(MULE_APP_DOMAIN, "MULE_APP_DOMAIN")
         .containsEntry(MULE_APP_FULL_DOMAIN, "MULE_APP_FULL_DOMAIN")
-        .containsEntry(MULE_ENVIRONMENT_AWS_REGION, "MULE_APP_AWS_REGION");
+        .containsEntry(MULE_ENVIRONMENT_AWS_REGION, "MULE_APP_AWS_REGION")
+        .containsKey(ProcessIncubatingAttributes.PROCESS_PID)
+        .containsKey(ProcessIncubatingAttributes.PROCESS_EXECUTABLE_PATH);
     props.forEach((key, value) -> System.clearProperty(key.toString()));
   }
 }


### PR DESCRIPTION
#297 disables process resource provider which also remvoed `process.id` and `process.executable.path` attributes. This PR fixes that by selectively just adding those two attributes. `process.command_line` and `process.command_args` are still skipped for data sensitivity and resource processing cost purposes. Also fixes #229 by not needing users to disable the attributes.