### PR TITLE
fix: nullpointerexception while getting trace context from empty map

### DIFF
--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
@@ -269,6 +269,9 @@ public class OpenTelemetryConnection implements TraceContextHandler,
   public Map<String, Object> getTraceContext(String transactionId, String componentLocation) {
     TransactionContext transactionContext = getTransactionStore().getTransactionContext(transactionId,
         componentLocation);
+    if (transactionContext == null) {
+      return new HashMap<>();
+    }
     Map<String, Object> traceContext = transactionContext.getTraceContextMap();
     injectTraceContext(transactionContext.getContext(), traceContext,
         HashMapObjectMapSetter.INSTANCE);

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptor.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/interceptor/ProcessorTracingInterceptor.java
@@ -73,8 +73,11 @@ public class ProcessorTracingInterceptor implements ProcessorInterceptor {
         if (processorComponent == null) {
           // when spanAllProcessor is false, and it's the first generic processor
           String transactionId = getEventTransactionId(event);
-          addTraceContextMap(event,
-              muleNotificationProcessor.getOpenTelemetryConnection().getTraceContext(transactionId));
+          Map<String, Object> traceContext = muleNotificationProcessor.getOpenTelemetryConnection()
+              .getTraceContext(transactionId);
+          if (!traceContext.isEmpty()) {
+            addTraceContextMap(event, traceContext);
+          }
         } else {
           Component component = componentRegistryService.findComponentByLocation(location);
 

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
@@ -135,7 +135,7 @@ public class InMemoryTransactionStore implements TransactionStore {
     }
     ProcessorSpan processorSpan = transaction.findSpan(componentLocation);
     if (processorSpan != null) {
-    return TransactionContext.of(processorSpan.getSpan(), transaction);
+      return TransactionContext.of(processorSpan.getSpan(), transaction);
     } else {
       return transaction.getTransactionContext();
     }

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
@@ -127,13 +127,15 @@ public class InMemoryTransactionStore implements TransactionStore {
   @Override
   public TransactionContext getTransactionContext(String transactionId, String componentLocation) {
     Transaction transaction = getTransaction(transactionId);
-    if (componentLocation == null)
+    if (transaction == null) {
+      return null;
+    }
+    if (componentLocation == null) {
       return transaction.getTransactionContext();
-    ProcessorSpan processorSpan = null;
-    if (transaction != null
-        && ((processorSpan = transaction
-            .findSpan(componentLocation)) != null)) {
-      return TransactionContext.of(processorSpan.getSpan(), transaction);
+    }
+    ProcessorSpan processorSpan = transaction.findSpan(componentLocation);
+    if (processorSpan != null) {
+    return TransactionContext.of(processorSpan.getSpan(), transaction);
     } else {
       return transaction.getTransactionContext();
     }

--- a/mule-module/src/test/docker/docker-compose.yml
+++ b/mule-module/src/test/docker/docker-compose.yml
@@ -2,17 +2,17 @@ version: '3.9'
 
 services:
   zipkin:
-    image: "openzipkin/zipkin:2"
+    image: "openzipkin/zipkin-slim"
     ports:
       - "9411:9411"
     networks:
       - tracing
-  
+
   otelCollector:
-    image: "otel/opentelemetry-collector:0.42.0"
+    image: "otel/opentelemetry-collector:0.136.0"
     command: ["--config=/otel-local-config.yml"]
     ports:
-      - "55681:55681"
+      - "4318:4318"
     volumes:
       - "${PWD}/otel-local-config.yml:/otel-local-config.yml"
     networks:

--- a/mule-module/src/test/docker/otel-local-config.yml
+++ b/mule-module/src/test/docker/otel-local-config.yml
@@ -1,15 +1,14 @@
 receivers:
   otlp:
     protocols:
-      grpc:
       http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:
 
 exporters:
-  logging:
-    logLevel: debug
+  debug:
   zipkin:
     endpoint: "http://zipkin:9411/api/v2/spans"
 
@@ -18,4 +17,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, zipkin]
+      exporters: [debug,zipkin]


### PR DESCRIPTION
Sometimes, an attempt is made to load a transaction from a ConcurrentHashMap even though no entry exists. This leads to an exception in the InMemoryStore. This error is difficult to reproduce and is independent of the load on the system.

I also modified the Docker Compose file.

`(Get Current Trace Context)) Payload Type : org.mule.runtime.core.internal.streaming.bytes.ManagedCursorStreamProvider -------------------------------------------------------------------------------- Root Exception stack trace: java.lang.NullPointerException: Cannot invoke "com.avioconsulting.mule.opentelemetry.internal.store.Transaction.getTransactionContext()" because "transaction" is null at com.avioconsulting.mule.opentelemetry.internal.store.InMemoryTransactionStore.getTransactionContext(InMemoryTransactionStore.java:138) at com.avioconsulting.mule.opentelemetry.internal.connection.OpenTelemetryConnection.getTraceContext(OpenTelemetryConnection.java:270) at com.avioconsulting.mule.opentelemetry.internal.OpenTelemetryOperations.getCurrentTraceContext(OpenTelemetryOperations.java:75) at com.avioconsulting.mule.opentelemetry.internal.OpenTelemetryOperations$getCurrentTraceContext$MethodComponentExecutor_itsm_pam_servicenow_dapi_mule_application.execute(Unknown Source) at org.mule.runtime.extensions.support@4.6.22/org.mule.runtime.module.extension.internal.runtime.execution.GeneratedMethodComponentExecutor.execute(GeneratedMethodComponentExecutor.java:94) at org.mule.runtime.extensions.support@4.6.22/org.mule.runtime.module.extension.internal.runtime.execution.CompletableMethodOperationExecutor.doExecute(CompletableMethodOperationExecutor.java:26)

`