### PR TITLE
fix: export resource file to be visible on classpath

### DIFF
--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryExtension.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/OpenTelemetryExtension.java
@@ -28,7 +28,9 @@ import org.mule.sdk.api.meta.JavaVersion;
 @SubTypeMapping(baseType = OpenTelemetryMetricsConfigProvider.class, subTypes = {
     NoopOpenTelemetryMetricsConfigProvider.class })
 @Export(classes = { OpenTelemetryMetricsConfigProvider.class, AppIdentifier.class, OpenTelemetryMetricsProvider.class,
-    MetricBaseNotificationData.class, OpenTelemetryMetricsConfigSupplier.class, LogsApiPackageMarker.class })
+    MetricBaseNotificationData.class, OpenTelemetryMetricsConfigSupplier.class,
+    LogsApiPackageMarker.class }, resources = {
+        "com/avioconsulting/mule/opentelemetry/internal/interceptor/intercept-components.txt" })
 @JavaVersionSupport({ JavaVersion.JAVA_8, JavaVersion.JAVA_11, JavaVersion.JAVA_17 })
 public class OpenTelemetryExtension {
 }


### PR DESCRIPTION
Resource lookup is failing on runtime 4.10.0 and requires resources to be explicitely exported by extension.