### PR TITLE
fix: NPE guards with pooling

### DIFF
--- a/mule-module/pom.xml
+++ b/mule-module/pom.xml
@@ -340,6 +340,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <tags>
+            <tag>
+              <name>default</name>
+              <!-- Placement options: a (all), t (types), m (methods), f (fields), etc. -->
+              <placement>f</placement>
+              <head>Default Value for Field:</head>
+            </tag>
+          </tags>
           <!-- Added here to change doc destination path from parent -->
           <destDir>../target/docs/apidocs</destDir>
         </configuration>

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/api/traces/TraceComponent.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/api/traces/TraceComponent.java
@@ -62,7 +62,7 @@ public class TraceComponent implements ComponentEventContext, AutoCloseable, Cle
    * 
    * @param name
    *            Trace component name
-   * @return
+   * @return {@link TraceComponent}
    */
   @Deprecated
   public static TraceComponent of(String name) {
@@ -75,7 +75,7 @@ public class TraceComponent implements ComponentEventContext, AutoCloseable, Cle
    *
    * @param name
    *            Trace component name
-   * @return
+   * @return {@link TraceComponent}
    */
   @Deprecated
   public static TraceComponent of(String name, ComponentLocation location) {
@@ -90,7 +90,7 @@ public class TraceComponent implements ComponentEventContext, AutoCloseable, Cle
    *
    * @param component
    *            Trace component name
-   * @return
+   * @return {@link TraceComponent}
    */
   @Deprecated
   public static TraceComponent of(Component component) {
@@ -103,7 +103,7 @@ public class TraceComponent implements ComponentEventContext, AutoCloseable, Cle
    *
    * @param location
    *            Trace component name
-   * @return
+   * @return {@link TraceComponent}
    */
   @Deprecated
   public static TraceComponent of(ComponentLocation location) {
@@ -205,12 +205,10 @@ public class TraceComponent implements ComponentEventContext, AutoCloseable, Cle
 
   public TraceComponent withLocation(String val) {
     location = val;
-    if (val == null) {
-      contextScopedLocation = null;
-      return this;
-    }
-    if (getEventContextId() != null && contextScopedLocation == null) {
+    if (val != null && getEventContextId() != null) {
       contextScopedLocation = getEventContextId() + "/" + val;
+    } else {
+      contextScopedLocation = null;
     }
     return this;
   }
@@ -253,8 +251,10 @@ public class TraceComponent implements ComponentEventContext, AutoCloseable, Cle
       contextNestingLevel = 0;
       return this;
     }
-    if (getLocation() != null && contextScopedLocation == null) {
+    if (getLocation() != null) {
       contextScopedLocation = eventContextId + "/" + getLocation();
+    } else {
+      contextScopedLocation = null;
     }
     eventContextPrimaryId = eventContextId.contains(UNDERSCORE)
         ? eventContextId.substring(0, eventContextId.indexOf(UNDERSCORE))

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/api/traces/TransactionContext.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/api/traces/TransactionContext.java
@@ -40,6 +40,28 @@ public class TransactionContext {
     return transactionContext;
   }
 
+  /**
+   * Creates a new instance of {@code TransactionContext} and initializes it with
+   * the provided
+   * transaction ID. The trace context map is populated with the transaction ID,
+   * Invalid trace ID,
+   * and Invalid span ID.
+   *
+   * @param transactionId
+   *            the unique identifier for a transaction
+   * @return a new {@code TransactionContext} instance containing the provided
+   *         transaction ID
+   *         along with associated trace and span information in its trace context
+   *         map
+   */
+  public static TransactionContext of(String transactionId) {
+    TransactionContext transactionContext = new TransactionContext();
+    transactionContext.traceContextMap.put(TRACE_TRANSACTION_ID, transactionId);
+    transactionContext.traceContextMap.put(TransactionStore.traceId, transactionContext.getTraceId());
+    transactionContext.traceContextMap.put(TransactionStore.spanId, transactionContext.getSpanId());
+    return transactionContext;
+  }
+
   public static TransactionContext current() {
     return new TransactionContext();
   }

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnection.java
@@ -368,7 +368,9 @@ public class OpenTelemetryConnection implements TraceContextHandler,
           parentSpan = addRouteSpan(parentTrace, traceComponent, parentLocation,
               getLocationParent(parentLocation));
         }
-        spanBuilder.setParent(parentSpan.getContext());
+        if (parentSpan != null) {
+          spanBuilder.setParent(parentSpan.getContext());
+        }
       }
     }
 
@@ -398,9 +400,11 @@ public class OpenTelemetryConnection implements TraceContextHandler,
         traceComponent,
         span -> {
           if (error != null) {
-            span.recordException(error.getCause());
-            traceComponent.addTag(ERROR_TYPE.getKey(),
-                error.getCause().getClass().getCanonicalName());
+            Throwable cause = error.getCause();
+            if (cause != null) {
+              span.recordException(cause);
+              traceComponent.addTag(ERROR_TYPE.getKey(), cause.getClass().getCanonicalName());
+            }
             traceComponent.addTag(ERROR_MESSAGE.getKey(),
                 error.getDescription());
             if (error.getErrorType() != null
@@ -418,21 +422,38 @@ public class OpenTelemetryConnection implements TraceContextHandler,
   }
 
   private void processBatchJob(SpanMeta spanMeta, TraceComponent traceComponent) {
-    if (!traceComponent.getName().equalsIgnoreCase(BATCH_JOB_TAG)) {
+    if (!BATCH_JOB_TAG.equalsIgnoreCase(traceComponent.getName())) {
       return;
     }
     String batchJobInstanceId = traceComponent.getTag(MULE_BATCH_JOB_INSTANCE_ID.getKey());
-    try (TraceComponent batchComponent = TraceComponentManager.getInstance()
-        .createTraceComponent(batchJobInstanceId, traceComponent.getTag(MULE_BATCH_JOB_NAME.getKey()),
-            traceComponent.getComponentLocation())) {
+    String batchJobName = traceComponent.getTag(MULE_BATCH_JOB_NAME.getKey());
+    if (batchJobInstanceId == null || batchJobName == null) {
+      if (logger.isWarnEnabled()) {
+        logger.warn("Skipping batch job span processing due to missing metadata. jobInstanceId={}, jobName={}",
+            batchJobInstanceId, batchJobName);
+      }
+      return;
+    }
+    TraceComponent batchTraceComponent;
+    if (traceComponent.getComponentLocation() != null) {
+      batchTraceComponent = TraceComponentManager.getInstance().createTraceComponent(batchJobInstanceId,
+          batchJobName,
+          traceComponent.getComponentLocation());
+    } else {
+      batchTraceComponent = TraceComponentManager.getInstance().createTraceComponent(batchJobInstanceId,
+          batchJobName);
+    }
+    try (TraceComponent batchComponent = batchTraceComponent) {
       batchComponent.withLocation(traceComponent.getLocation())
           .withTransactionId(batchJobInstanceId)
-          .withSpanName(traceComponent.getTag(MULE_BATCH_JOB_NAME.getKey()))
+          .withSpanName(batchJobName)
           .withSpanKind(SpanKind.SERVER)
-          .withContext(spanMeta.getContext())
           .withEventContextId(traceComponent.getEventContextId())
           .withStartTime(traceComponent.getStartTime());
-      batchComponent.addAllTags(spanMeta.getTags());
+      if (spanMeta != null) {
+        batchComponent.withContext(spanMeta.getContext());
+        batchComponent.addAllTags(spanMeta.getTags());
+      }
       traceComponent.copyTagsTo(batchComponent);
       startTransaction(batchComponent);
       if (BatchHelperUtil.isBatchSupportDisabled()) {

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/Borrowable.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/Borrowable.java
@@ -2,9 +2,16 @@ package com.avioconsulting.mule.opentelemetry.internal.processor.util;
 
 import com.avioconsulting.mule.opentelemetry.api.traces.TraceComponent;
 
-public interface Borrowable {
+/**
+ *
+ * This interface is marked as deprecated and may be removed in future
+ * versions.
+ *
+ * @see Leasable
+ */
 
-  String getId();
+@Deprecated
+public interface Borrowable {
 
   long getBorrowedAt();
 

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/Borrowable.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/Borrowable.java
@@ -3,6 +3,9 @@ package com.avioconsulting.mule.opentelemetry.internal.processor.util;
 import com.avioconsulting.mule.opentelemetry.api.traces.TraceComponent;
 
 public interface Borrowable {
+
+  String getId();
+
   long getBorrowedAt();
 
   TraceComponent withBorrowedAt(long borrowedAt);

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/Leasable.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/Leasable.java
@@ -1,0 +1,31 @@
+package com.avioconsulting.mule.opentelemetry.internal.processor.util;
+
+/**
+ * Internal lifecycle contract for pooled components tracked by lease.
+ *
+ * <p>
+ * This interface was introduced as an incremental step away from the older
+ * {@code Borrowable} model toward explicit lease semantics. Pool and manager
+ * logic requires two distinct signals:
+ *
+ * <ul>
+ * <li><b>Lease generation</b> via {@link #getActiveLease()} to detect stale
+ * close/release attempts when a component has already been re-acquired for a
+ * newer lifecycle.</li>
+ * <li><b>Lease start time</b> via {@link #getLeasedAt()} to compute age-based
+ * cleanup thresholds for components that were not properly closed.</li>
+ * </ul>
+ *
+ * <p>
+ * The combination of immutable component identity ({@link #getId()}) and
+ * lease metadata allows {@code TraceComponentManager} to manage concurrency
+ * safely while preserving time-based stale cleanup behavior.
+ */
+public interface Leasable {
+
+  String getId();
+
+  long getActiveLease();
+
+  long getLeasedAt();
+}

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/PooledTraceComponent.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/PooledTraceComponent.java
@@ -37,7 +37,11 @@ public class PooledTraceComponent extends TraceComponent implements Borrowable {
   }
 
   /**
-   * Resets the component for reuse with a new name.
+   * Resets the component for reuse with a new transaction id and name.
+   * State is already cleared by
+   * {@link TraceComponentPool#release(TraceComponent)}
+   * before the component is returned to the pool, so no explicit clear is needed
+   * here.
    */
   void reset(String transactionId, String name) {
     this.setName(name)
@@ -61,4 +65,11 @@ public class PooledTraceComponent extends TraceComponent implements Borrowable {
     return this;
   }
 
+  @Override
+  public String toString() {
+    return "PooledTraceComponent{" +
+        "id='" + id + '\'' +
+        ", borrowedAt=" + borrowedAt +
+        "} " + super.toString();
+  }
 }

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/PooledTraceComponent.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/PooledTraceComponent.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 /**
@@ -18,13 +19,17 @@ import java.util.function.Consumer;
  * identifier and support custom
  * cleanup actions upon closure, as specified by the {@code onClose} consumer.
  */
-public class PooledTraceComponent extends TraceComponent implements Borrowable {
+public class PooledTraceComponent extends TraceComponent implements Leasable {
   private final Consumer<TraceComponent> onClose;
 
   private static final int INITIAL_TAG_MAP_CAPACITY = 64;
 
   private final String id = UUID.randomUUID().toString();
-  private long borrowedAt;
+  private volatile long leasedAt;
+  private final AtomicLong leaseCounter = new AtomicLong(0);
+  private final AtomicLong lastClosedLease = new AtomicLong(-1);
+  private volatile long activeLease;
+  private volatile long ownerThreadId;
 
   PooledTraceComponent(String transactionId, String name, Consumer<TraceComponent> onClose) {
     super(name, new HashMap<>(INITIAL_TAG_MAP_CAPACITY));
@@ -49,27 +54,45 @@ public class PooledTraceComponent extends TraceComponent implements Borrowable {
         .withStartTime(Instant.now());
   }
 
+  long nextLease() {
+    this.activeLease = leaseCounter.incrementAndGet();
+    this.ownerThreadId = Thread.currentThread().getId();
+    this.leasedAt = System.currentTimeMillis();
+    return this.activeLease;
+  }
+
+  @Override
+  public long getActiveLease() {
+    return activeLease;
+  }
+
+  private boolean tryCloseCurrentLease() {
+    long currentLease = this.activeLease;
+    if (Thread.currentThread().getId() != ownerThreadId) {
+      return false;
+    }
+    return lastClosedLease.getAndSet(currentLease) != currentLease;
+  }
+
   @Override
   public void close() {
+    if (!tryCloseCurrentLease()) {
+      return;
+    }
     onClose.accept(this);
   }
 
   @Override
-  public long getBorrowedAt() {
-    return this.borrowedAt;
-  }
-
-  @Override
-  public TraceComponent withBorrowedAt(long borrowedAt) {
-    this.borrowedAt = borrowedAt;
-    return this;
+  public long getLeasedAt() {
+    return this.leasedAt;
   }
 
   @Override
   public String toString() {
     return "PooledTraceComponent{" +
         "id='" + id + '\'' +
-        ", borrowedAt=" + borrowedAt +
+        ", activeLease=" + activeLease +
+        ", leasedAt=" + leasedAt +
         "} " + super.toString();
   }
 }

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentManager.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentManager.java
@@ -85,6 +85,7 @@ public class TraceComponentManager {
   }
 
   private void clear() {
+    activeComponents.clear();
     pool.clear();
   }
 
@@ -192,10 +193,13 @@ public class TraceComponentManager {
       return;
     }
 
-    String key = getComponentKey(component);
+    String key = getPooledComponentId(component);
     if (key != null) {
       activeComponents.remove(key);
     }
+
+    String txId = component.getTransactionId();
+    String location = component.getLocation();
 
     // Return the component to the pool for reuse
     if (usePooling) {
@@ -203,109 +207,50 @@ public class TraceComponentManager {
     }
 
     if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("Closed TraceComponent: {}", key);
+      LOGGER.trace("Closed TraceComponent: {} (txId={}, location={})", key, txId, location);
     }
   }
 
   /**
-   * Releases a component back to the pool and removes tracking.
-   * This method is for external callers who want to manually release components.
-   * 
-   * @param component
-   *            the component to release
-   */
-  public void releaseComponent(TraceComponent component) {
-    if (component == null) {
-      return;
-    }
-
-    // For PooledTraceComponent, call close() which will trigger
-    // handleComponentClose
-    if (component instanceof PooledTraceComponent) {
-      try {
-        component.close();
-      } catch (Exception e) {
-        LOGGER.warn("Error closing PooledTraceComponent", e);
-      }
-    } else {
-      // For non-pooled components, just log
-      String key = getComponentKey(component);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Released non-pooled TraceComponent: {}", key);
-      }
-    }
-  }
-
-  /**
-   * Releases a component by transaction ID and location.
-   * 
-   * @param transactionId
-   *            the transaction ID
-   * @param location
-   *            the component location
-   */
-  public void releaseComponent(String transactionId, String location) {
-    String key = generateKey(transactionId, location);
-    Borrowable borrowed = activeComponents.remove(key);
-
-    if (borrowed != null) {
-      releaseComponent((TraceComponent) borrowed);
-
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Released TraceComponent by key: {}", key);
-      }
-    }
-  }
-
-  /**
-   * Tracks a component for lifecycle management.
+   * Tracks a component for lifecycle management using the PooledTraceComponent's
+   * immutable UUID as the tracking key. This eliminates key-mismatch bugs that
+   * occurred when using mutable fields (transactionId|location) which could
+   * change
+   * between tracking and close time.
    */
   private void trackComponent(TraceComponent component) {
     if (component == null || !usePooling) {
       return;
     }
 
-    String key = getComponentKey(component);
-    if (key != null && component instanceof Borrowable) {
+    String key = getPooledComponentId(component);
+    if (key != null) {
       activeComponents.put(key, (Borrowable) component);
 
       if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Tracking TraceComponent: {}", key);
+        LOGGER.trace("Tracking TraceComponent: {} (txId={}, location={})", key,
+            component.getTransactionId(), component.getLocation());
       }
     }
   }
 
   /**
-   * Generates a tracking key for a component.
+   * Returns the immutable UUID of a PooledTraceComponent for use as a tracking
+   * key.
+   * Returns null for non-pooled components (which are not tracked).
    */
-  private String getComponentKey(TraceComponent component) {
-    String transactionId = component.getTransactionId();
-    String location = component.getLocation();
-
-    if (transactionId == null && location == null) {
-      // Can't track without identifiers
-      return null;
+  private String getPooledComponentId(TraceComponent component) {
+    if (component instanceof PooledTraceComponent) {
+      return ((PooledTraceComponent) component).getId();
     }
-
-    return generateKey(transactionId, location);
-  }
-
-  /**
-   * Generates a tracking key from transaction ID and location.
-   */
-  private String generateKey(String transactionId, String location) {
-    if (transactionId != null && location != null) {
-      return transactionId + "|" + location;
-    } else if (transactionId != null) {
-      return transactionId + "|";
-    } else {
-      return "|" + location;
-    }
+    return null;
   }
 
   /**
    * Cleans up stale components that haven't been released.
    * This prevents memory leaks from components that weren't properly released.
+   * Returns stale components directly to the pool (bypassing close()) to avoid
+   * races with concurrent close/release/acquire cycles.
    */
   private void cleanupStaleComponents() {
     long now = System.currentTimeMillis();
@@ -315,11 +260,19 @@ public class TraceComponentManager {
       Borrowable borrowed = entry.getValue();
       if (now - borrowed.getBorrowedAt() > MAX_COMPONENT_AGE_MILLIS) {
         if (activeComponents.remove(entry.getKey(), borrowed)) {
-          releaseComponent((TraceComponent) borrowed);
+          TraceComponent tc = (TraceComponent) borrowed;
+          // Capture for logging before release clears the fields
+          String txId = tc.getTransactionId();
+          String location = tc.getLocation();
+          // Return directly to pool rather than calling close() to avoid
+          // a race where the component has already been re-acquired after
+          // a concurrent close/release/acquire cycle.
+          pool.release(tc);
           cleaned++;
 
           if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Cleaned up stale TraceComponent: {}", entry.getKey());
+            LOGGER.debug("Cleaned up stale TraceComponent: id={}, txId={}, location={}",
+                entry.getKey(), txId, location);
           }
         }
       } else if (now - borrowed.getBorrowedAt() > MAX_COMPONENT_AGE_MILLIS / 5) {
@@ -364,9 +317,10 @@ public class TraceComponentManager {
       Thread.currentThread().interrupt();
     }
 
-    // Release all active components
+    // Return all active components to the pool directly rather than
+    // calling close() to avoid races during shutdown.
     for (Borrowable borrowed : activeComponents.values()) {
-      releaseComponent((TraceComponent) borrowed);
+      pool.release((TraceComponent) borrowed);
     }
     activeComponents.clear();
   }

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentManager.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentManager.java
@@ -57,7 +57,8 @@ public class TraceComponentManager {
   private static final String MULE_OTEL_POOLING_TRACECOMPONENT_ENABLED = "mule.otel.pooling.tracecomponent.enabled";
 
   // Track active components for automatic cleanup
-  private final Map<String, Borrowable> activeComponents = new ConcurrentHashMap<>();
+  private final Map<String, Leasable> activeComponents = new ConcurrentHashMap<>();
+  private final Map<String, Long> activeLeases = new ConcurrentHashMap<>();
 
   // Cleanup configuration
   private static final long CLEANUP_INTERVAL_SECONDS = 120;
@@ -86,6 +87,7 @@ public class TraceComponentManager {
 
   private void clear() {
     activeComponents.clear();
+    activeLeases.clear();
     pool.clear();
   }
 
@@ -193,17 +195,38 @@ public class TraceComponentManager {
       return;
     }
 
-    String key = getPooledComponentId(component);
-    if (key != null) {
-      activeComponents.remove(key);
+    if (!(component instanceof PooledTraceComponent)) {
+      return;
     }
+
+    PooledTraceComponent pooled = (PooledTraceComponent) component;
+    long lease = pooled.getActiveLease();
+
+    String key = getPooledComponentId(component);
+    if (key == null) {
+      return;
+    }
+
+    Leasable tracked = activeComponents.get(key);
+    Long expectedLease = activeLeases.get(key);
+    if (tracked == null || tracked != pooled || expectedLease == null || expectedLease.longValue() != lease) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Ignoring close for stale/untracked TraceComponent: id={}, lease={}", key, lease);
+      }
+      return;
+    }
+
+    if (!activeComponents.remove(key, tracked)) {
+      return;
+    }
+    activeLeases.remove(key, expectedLease);
 
     String txId = component.getTransactionId();
     String location = component.getLocation();
 
     // Return the component to the pool for reuse
     if (usePooling) {
-      pool.release(component);
+      pool.release(component, lease);
     }
 
     if (LOGGER.isTraceEnabled()) {
@@ -223,9 +246,16 @@ public class TraceComponentManager {
       return;
     }
 
+    if (!(component instanceof PooledTraceComponent)) {
+      return;
+    }
+
+    PooledTraceComponent pooled = (PooledTraceComponent) component;
+
     String key = getPooledComponentId(component);
     if (key != null) {
-      activeComponents.put(key, (Borrowable) component);
+      activeLeases.put(key, pooled.getActiveLease());
+      activeComponents.put(key, pooled);
 
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace("Tracking TraceComponent: {} (txId={}, location={})", key,
@@ -256,28 +286,35 @@ public class TraceComponentManager {
     long now = System.currentTimeMillis();
     int cleaned = 0;
 
-    for (Map.Entry<String, Borrowable> entry : activeComponents.entrySet()) {
-      Borrowable borrowed = entry.getValue();
-      if (now - borrowed.getBorrowedAt() > MAX_COMPONENT_AGE_MILLIS) {
-        if (activeComponents.remove(entry.getKey(), borrowed)) {
-          TraceComponent tc = (TraceComponent) borrowed;
+    for (Map.Entry<String, Leasable> entry : activeComponents.entrySet()) {
+      Leasable leased = entry.getValue();
+      String key = entry.getKey();
+      Long expectedLease = activeLeases.get(key);
+      if (expectedLease == null) {
+        continue;
+      }
+      if (now - leased.getLeasedAt() > MAX_COMPONENT_AGE_MILLIS) {
+        if (activeComponents.remove(key, leased)) {
+          activeLeases.remove(key, expectedLease);
+          TraceComponent tc = (TraceComponent) leased;
           // Capture for logging before release clears the fields
           String txId = tc.getTransactionId();
           String location = tc.getLocation();
           // Return directly to pool rather than calling close() to avoid
           // a race where the component has already been re-acquired after
           // a concurrent close/release/acquire cycle.
-          pool.release(tc);
+          pool.release(tc, expectedLease);
           cleaned++;
 
           if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Cleaned up stale TraceComponent: id={}, txId={}, location={}",
-                entry.getKey(), txId, location);
+                key, txId, location);
           }
         }
-      } else if (now - borrowed.getBorrowedAt() > MAX_COMPONENT_AGE_MILLIS / 5) {
+      } else if (now - leased.getLeasedAt() > MAX_COMPONENT_AGE_MILLIS / 2) {
         if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug("Stale TraceComponent still active Key: {}, component: {}", entry.getKey(), borrowed);
+          LOGGER.debug("Stale TraceComponent still active Key: {}, component: {}", entry.getKey(),
+              leased);
         }
       }
     }
@@ -319,10 +356,14 @@ public class TraceComponentManager {
 
     // Return all active components to the pool directly rather than
     // calling close() to avoid races during shutdown.
-    for (Borrowable borrowed : activeComponents.values()) {
-      pool.release((TraceComponent) borrowed);
+    for (Map.Entry<String, Leasable> entry : activeComponents.entrySet()) {
+      Long expectedLease = activeLeases.get(entry.getKey());
+      if (expectedLease != null) {
+        pool.release((TraceComponent) entry.getValue(), expectedLease.longValue());
+      }
     }
     activeComponents.clear();
+    activeLeases.clear();
   }
 
 }

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentPool.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentPool.java
@@ -59,20 +59,21 @@ public class TraceComponentPool {
       currentPoolSize.decrementAndGet();
       componentsReused.incrementAndGet();
       pooled.reset(transactionId, name);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Reused TraceComponent from pool (pool size: {}) - {} - {}", currentPoolSize.get(),
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Reused TraceComponent from pool (pool size: {}) - {} - {}", currentPoolSize.get(),
             pooled.getId() + " - " + pooled.getName(), pooled);
       }
-      return pooled.withBorrowedAt(System.currentTimeMillis());
+      pooled.nextLease();
+      return pooled;
     }
 
     // Create new if pool is empty
     componentsCreated.incrementAndGet();
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("Created new TraceComponent (total created: {})", componentsCreated.get());
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Created new TraceComponent (total created: {})", componentsCreated.get());
     }
-    TraceComponent traceComponent = new PooledTraceComponent(transactionId, name, onClose).withBorrowedAt(
-        System.currentTimeMillis());
+    PooledTraceComponent traceComponent = new PooledTraceComponent(transactionId, name, onClose);
+    traceComponent.nextLease();
     return traceComponent;
   }
 
@@ -102,8 +103,21 @@ public class TraceComponentPool {
     if (!(component instanceof PooledTraceComponent)) {
       return;
     }
+    release(component, ((PooledTraceComponent) component).getActiveLease());
+  }
 
+  public void release(TraceComponent component, long expectedLease) {
+    if (!(component instanceof PooledTraceComponent)) {
+      return;
+    }
     PooledTraceComponent pooled = (PooledTraceComponent) component;
+    if (pooled.getActiveLease() != expectedLease) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Ignoring stale TraceComponent release. id={}, expectedLease={}, activeLease={}",
+            pooled.getId(), expectedLease, pooled.getActiveLease());
+      }
+      return;
+    }
     if (LOGGER.isTraceEnabled()) {
       LOGGER.trace("Returning TraceComponent to pool (pool size: {}): {} - {}", currentPoolSize.get(),
           pooled.getId() + " - " + pooled.getName(), pooled);
@@ -117,8 +131,8 @@ public class TraceComponentPool {
       currentPoolSize.incrementAndGet();
       componentsReturned.incrementAndGet();
 
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Returned TraceComponent to pool (pool size: {}) - {}", currentPoolSize.get(), pooled);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Returned TraceComponent to pool (pool size: {}) - {}", currentPoolSize.get(), pooled);
       }
     }
   }

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
@@ -135,7 +135,7 @@ public class InMemoryTransactionStore implements TransactionStore {
   public TransactionContext getTransactionContext(String transactionId, String componentLocation) {
     Transaction transaction = getTransaction(transactionId);
     if (transaction == null) {
-      LOGGER.debug("getTransactionContext: no transaction found for id '{}', returning null context",
+      LOGGER.debug("getTransactionContext: no transaction found for id '{}', returning fallback context",
           transactionId);
       return TransactionContext.of(transactionId);
     }

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStore.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
@@ -114,6 +115,10 @@ public class InMemoryTransactionStore implements TransactionStore {
     String format = "%s.%s";
     tags.forEach((k, v) -> builder.put(String.format(format, tagPrefix, k), v));
     Transaction transaction = getTransaction(transactionId);
+    if (transaction == null) {
+      LOGGER.debug("addTransactionTags: no transaction found for id '{}', skipping tag update", transactionId);
+      return;
+    }
     Span span = transaction.getTransactionSpan();
     if (span != null) {
       span.setAllAttributes(builder.build());
@@ -121,18 +126,23 @@ public class InMemoryTransactionStore implements TransactionStore {
   }
 
   private Transaction getTransaction(String transactionId) {
+    if (transactionId == null)
+      return null;
     return transactionMap.get(transactionId);
   }
 
   @Override
   public TransactionContext getTransactionContext(String transactionId, String componentLocation) {
     Transaction transaction = getTransaction(transactionId);
+    if (transaction == null) {
+      LOGGER.debug("getTransactionContext: no transaction found for id '{}', returning null context",
+          transactionId);
+      return TransactionContext.of(transactionId);
+    }
     if (componentLocation == null)
       return transaction.getTransactionContext();
     ProcessorSpan processorSpan = null;
-    if (transaction != null
-        && ((processorSpan = transaction
-            .findSpan(componentLocation)) != null)) {
+    if ((processorSpan = transaction.findSpan(componentLocation)) != null) {
       return TransactionContext.of(processorSpan.getSpan(), transaction);
     } else {
       return transaction.getTransactionContext();
@@ -163,7 +173,10 @@ public class InMemoryTransactionStore implements TransactionStore {
     Transaction transaction = getTransaction(traceComponent.getTransactionId());
     TransactionMeta transactionMeta = transaction;
     if (transaction != null) {
-      if (transaction.getRootFlowName().equals(traceComponent.getName())) {
+      if (transaction.getRootFlowName() == null) {
+        LOGGER.warn("Root flow name is null for transaction {}", transaction.getTransactionId());
+      }
+      if (Objects.equals(transaction.getRootFlowName(), traceComponent.getName())) {
         if (LOGGER.isTraceEnabled()) {
           LOGGER.trace("Marking the end time of transaction {} from map for {} - Context Id {}",
               traceComponent.getTransactionId(),
@@ -222,6 +235,13 @@ public class InMemoryTransactionStore implements TransactionStore {
     }
     SpanMeta span = transaction
         .addProcessorSpan(containerName, traceComponent, spanBuilder);
+    if (span == null) {
+      if (LOGGER.isWarnEnabled()) {
+        LOGGER.warn("Failed to add processor span for transaction {} at location {}",
+            traceComponent.getTransactionId(), traceComponent.getLocation());
+      }
+      return null;
+    }
     if (LOGGER.isTraceEnabled()) {
       LOGGER.trace(
           "Adding Processor span to transaction {} for locator span '{}': OT SpanId {}, TraceId {}",

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/MDCUtil.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/MDCUtil.java
@@ -1,6 +1,8 @@
 package com.avioconsulting.mule.opentelemetry.internal.util;
 
 import com.avioconsulting.mule.opentelemetry.api.store.TransactionStore;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
 import org.mule.runtime.api.event.Event;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.slf4j.MDC;
@@ -32,19 +34,26 @@ public class MDCUtil {
   public static void replaceMDCOtelEntries(Map<String, Object> context) {
     if (context == null || context.isEmpty())
       return;
-    replaceMDCOtelEntry(context, traceId, TRACE_ID);
-    replaceMDCOtelEntry(context, spanId, SPAN_ID);
+    // In rare cases, the traceId and spanId can be invalid
+    // In such cases, don't replace existing MDC entries
+    replaceMDCOtelEntry(context, traceId, TRACE_ID, TraceId.getInvalid());
+    replaceMDCOtelEntry(context, spanId, SPAN_ID, SpanId.getInvalid());
   }
 
-  private static void replaceMDCOtelEntry(Map<String, Object> contextMap, String sourceKey, String targetKey) {
+  private static void replaceMDCOtelEntry(Map<String, Object> contextMap, String sourceKey, String targetKey,
+      String invalidValue) {
     if (contextMap.containsKey(sourceKey)) {
       String mdcValue = MDC.get(sourceKey);
+      String newValue = contextMap.get(sourceKey).toString();
+      if (newValue.equalsIgnoreCase(invalidValue)) {
+        return;
+      }
       if (mdcValue != null &&
-          mdcValue.equalsIgnoreCase(contextMap.get(sourceKey).toString())) {
+          mdcValue.equalsIgnoreCase(newValue)) {
         return;
       }
       MDC.remove(targetKey);
-      MDC.put(targetKey, contextMap.get(sourceKey).toString());
+      MDC.put(targetKey, newValue);
     }
   }
 }

--- a/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/MDCUtil.java
+++ b/mule-module/src/main/java/com/avioconsulting/mule/opentelemetry/internal/util/MDCUtil.java
@@ -43,8 +43,12 @@ public class MDCUtil {
   private static void replaceMDCOtelEntry(Map<String, Object> contextMap, String sourceKey, String targetKey,
       String invalidValue) {
     if (contextMap.containsKey(sourceKey)) {
-      String mdcValue = MDC.get(sourceKey);
-      String newValue = contextMap.get(sourceKey).toString();
+      String mdcValue = MDC.get(targetKey);
+      Object rawValue = contextMap.get(sourceKey);
+      if (rawValue == null) {
+        return;
+      }
+      String newValue = rawValue.toString();
       if (newValue.equalsIgnoreCase(invalidValue)) {
         return;
       }

--- a/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnectionTest.java
+++ b/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/connection/OpenTelemetryConnectionTest.java
@@ -5,24 +5,35 @@ import com.avioconsulting.mule.opentelemetry.api.config.ExporterConfiguration;
 import com.avioconsulting.mule.opentelemetry.api.config.OpenTelemetryResource;
 import com.avioconsulting.mule.opentelemetry.api.config.SpanProcessorConfiguration;
 import com.avioconsulting.mule.opentelemetry.api.config.exporter.OpenTelemetryExporter;
+import com.avioconsulting.mule.opentelemetry.api.config.exporter.LoggingExporter;
 import com.avioconsulting.mule.opentelemetry.api.notifications.MetricBaseNotificationData;
 import com.avioconsulting.mule.opentelemetry.api.providers.NoopOpenTelemetryMetricsConfigProvider;
 import com.avioconsulting.mule.opentelemetry.api.providers.OpenTelemetryMetricsConfigProvider;
 import com.avioconsulting.mule.opentelemetry.api.providers.OpenTelemetryMetricsProvider;
 import com.avioconsulting.mule.opentelemetry.api.store.SpanMeta;
 import com.avioconsulting.mule.opentelemetry.api.store.TransactionMeta;
+import com.avioconsulting.mule.opentelemetry.api.traces.TraceComponent;
 import com.avioconsulting.mule.opentelemetry.internal.AbstractInternalTest;
 import com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryConfigWrapper;
 import com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryConfiguration;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.message.Error;
+import org.mule.runtime.api.message.ErrorType;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.avioconsulting.mule.opentelemetry.api.store.TransactionStore.TRACE_TRANSACTION_ID;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class OpenTelemetryConnectionTest extends AbstractInternalTest {
@@ -44,6 +55,48 @@ public class OpenTelemetryConnectionTest extends AbstractInternalTest {
     verify(resource).getConfigMap();
     verify(exporter).getExporterProperties();
     verify(spc).getConfigMap();
+  }
+
+  @Test
+  public void getTraceContext_returnsFallbackContext_whenTransactionMissing() {
+    OpenTelemetryResource resource = mock(OpenTelemetryResource.class);
+    ExporterConfiguration exporterConfig = mock(ExporterConfiguration.class);
+    OpenTelemetryExporter exporter = mock(OpenTelemetryExporter.class);
+    when(exporterConfig.getExporter()).thenReturn(exporter);
+    SpanProcessorConfiguration spc = mock(SpanProcessorConfiguration.class);
+    OpenTelemetryConfiguration configuration = mock(OpenTelemetryConfiguration.class);
+    when(configuration.getResource()).thenReturn(resource);
+    when(configuration.getExporterConfiguration()).thenReturn(exporterConfig);
+    when(configuration.getSpanProcessorConfiguration()).thenReturn(spc);
+    OpenTelemetryConfigWrapper wrapper = new OpenTelemetryConfigWrapper(configuration);
+    OpenTelemetryConnection instance = OpenTelemetryConnection.getInstance(wrapper);
+
+    String txId = "missing-tx-id";
+    Map<String, Object> traceContext = instance.getTraceContext(txId);
+
+    assertThat(traceContext).isNotNull();
+    assertThat(traceContext).containsEntry(TRACE_TRANSACTION_ID, txId);
+  }
+
+  @Test
+  public void getTraceContext_withLocation_returnsFallbackContext_whenTransactionMissing() {
+    OpenTelemetryResource resource = mock(OpenTelemetryResource.class);
+    ExporterConfiguration exporterConfig = mock(ExporterConfiguration.class);
+    OpenTelemetryExporter exporter = mock(OpenTelemetryExporter.class);
+    when(exporterConfig.getExporter()).thenReturn(exporter);
+    SpanProcessorConfiguration spc = mock(SpanProcessorConfiguration.class);
+    OpenTelemetryConfiguration configuration = mock(OpenTelemetryConfiguration.class);
+    when(configuration.getResource()).thenReturn(resource);
+    when(configuration.getExporterConfiguration()).thenReturn(exporterConfig);
+    when(configuration.getSpanProcessorConfiguration()).thenReturn(spc);
+    OpenTelemetryConfigWrapper wrapper = new OpenTelemetryConfigWrapper(configuration);
+    OpenTelemetryConnection instance = OpenTelemetryConnection.getInstance(wrapper);
+
+    String txId = "missing-tx-id-with-location";
+    Map<String, Object> traceContext = instance.getTraceContext(txId, "flow/processors/0");
+
+    assertThat(traceContext).isNotNull();
+    assertThat(traceContext).containsEntry(TRACE_TRANSACTION_ID, txId);
   }
 
   @Test
@@ -199,6 +252,69 @@ public class OpenTelemetryConnectionTest extends AbstractInternalTest {
         "Any exception from Metrics providers default settings (Enabled, None) with another provider on classpath")
         .isNull();
     Assertions.assertThat(store.get("flow")).isEqualTo(transactionMeta);
+  }
+
+  /**
+   * H8: {@code endProcessorSpan} must not throw a NullPointerException when
+   * {@code error.getCause()} returns {@code null} (e.g., synthetic Mule errors
+   * that have no underlying Java exception).
+   */
+  @Test
+  public void endProcessorSpan_doesNotThrowNPE_whenErrorCauseIsNull() {
+    // Arrange — build a minimal connection with a logging exporter
+    com.avioconsulting.mule.opentelemetry.api.config.exporter.LoggingExporter loggingExporter = new LoggingExporter();
+    ExporterConfiguration exporterConfiguration = new ExporterConfiguration();
+    exporterConfiguration.setExporter(loggingExporter);
+    com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryExtensionConfiguration configuration = new com.avioconsulting.mule.opentelemetry.internal.config.OpenTelemetryExtensionConfiguration();
+    configuration.setExporterConfiguration(exporterConfiguration);
+    OpenTelemetryConfigWrapper wrapper = new OpenTelemetryConfigWrapper(configuration);
+    OpenTelemetryConnection conn = OpenTelemetryConnection.getInstance(wrapper);
+
+    Tracer tracer = GlobalOpenTelemetry.get().getTracer("h8-test", "v1");
+    Instant now = Instant.now();
+
+    // Start a root transaction
+    String txId = "h8-tx";
+    String flowName = "h8-flow";
+    String location = flowName + "/processors/0";
+    TraceComponent startTc = TraceComponent.of(flowName, new HashMap<>())
+        .withTransactionId(txId)
+        .withSpanName(flowName)
+        .withStartTime(now)
+        .withLocation(location)
+        .withEventContextId(txId + "-ctx");
+    SpanBuilder rootSpan = tracer.spanBuilder(flowName).setSpanKind(SpanKind.SERVER).setStartTimestamp(now);
+    conn.getTransactionStore().startTransaction(startTc, flowName, rootSpan);
+
+    // Add a processor span so endProcessorSpan has something to end
+    TraceComponent processorTc = TraceComponent.of(flowName, new HashMap<>())
+        .withTransactionId(txId)
+        .withSpanName("logger")
+        .withStartTime(now)
+        .withLocation(location)
+        .withEventContextId(txId + "-ctx");
+    conn.getTransactionStore().addProcessorSpan(flowName, processorTc,
+        tracer.spanBuilder("logger").setSpanKind(SpanKind.INTERNAL));
+
+    // Build an Error whose getCause() returns null (synthetic error, no Java cause)
+    Error syntheticError = mock(Error.class);
+    when(syntheticError.getCause()).thenReturn(null);
+    when(syntheticError.getDescription()).thenReturn("MULE:CONNECTIVITY");
+    ErrorType errorType = mock(ErrorType.class);
+    when(errorType.toString()).thenReturn("MULE:CONNECTIVITY");
+    when(syntheticError.getErrorType()).thenReturn(errorType);
+
+    TraceComponent endTc = TraceComponent.of(flowName, new HashMap<>())
+        .withTransactionId(txId)
+        .withSpanName("logger")
+        .withStartTime(now)
+        .withEndTime(Instant.now())
+        .withLocation(location)
+        .withEventContextId(txId + "-ctx");
+
+    // Act & Assert — must not throw NPE
+    assertThatCode(() -> conn.endProcessorSpan(endTc, syntheticError))
+        .doesNotThrowAnyException();
   }
 
   public static class TestOpenTelemetryMetricsConfigProvider implements OpenTelemetryMetricsConfigProvider {

--- a/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentPoolTest.java
+++ b/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentPoolTest.java
@@ -362,4 +362,45 @@ public class TraceComponentPoolTest {
 
     executor.shutdown();
   }
+
+  @Test
+  public void shouldIgnoreStaleCloseFromPreviousThreadAfterReborrow() throws Exception {
+    TraceComponentPool[] holder = new TraceComponentPool[1];
+    holder[0] = new TraceComponentPool(component -> {
+      if (component instanceof PooledTraceComponent) {
+        holder[0].release(component, ((PooledTraceComponent) component).getActiveLease());
+      }
+    });
+    TraceComponentPool localPool = holder[0];
+    localPool.clear();
+
+    TraceComponent ownerARef = localPool.acquire("tx-a", "flow-a");
+    ownerARef.withLocation("flow-a/processors/0");
+    ownerARef.close();
+
+    final TraceComponent[] ownerBHolder = new TraceComponent[1];
+    Thread borrowerB = new Thread(() -> {
+      TraceComponent tc = localPool.acquire("tx-b", "flow-b");
+      tc.withLocation("flow-b/processors/0");
+      ownerBHolder[0] = tc;
+    });
+    borrowerB.start();
+    borrowerB.join();
+
+    TraceComponent ownerBRef = ownerBHolder[0];
+    assertThat(ownerBRef)
+        .as("test setup requires the same pooled instance to be reused")
+        .isSameAs(ownerARef);
+    assertThat(ownerBRef.getTransactionId()).isEqualTo("tx-b");
+
+    // Simulate delayed stale close from the previous owner thread (main/A).
+    ownerARef.close();
+
+    assertThat(ownerBRef.getTransactionId())
+        .as("stale close from previous thread must not clear active borrow")
+        .isEqualTo("tx-b");
+    assertThat(ownerBRef.getLocation())
+        .as("stale close from previous thread must not clear active borrow")
+        .isEqualTo("flow-b/processors/0");
+  }
 }

--- a/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentPoolTest.java
+++ b/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/processor/util/TraceComponentPoolTest.java
@@ -1,0 +1,365 @@
+package com.avioconsulting.mule.opentelemetry.internal.processor.util;
+
+import com.avioconsulting.mule.opentelemetry.api.traces.TraceComponent;
+import io.opentelemetry.api.trace.SpanKind;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link TraceComponentPool} and {@link PooledTraceComponent}
+ * focusing on thread-safety correctness after pool reuse.
+ *
+ * <p>
+ * Specifically covers the bug where
+ * {@link PooledTraceComponent#reset(String, String)}
+ * was not calling {@link TraceComponent#clear()} first, which caused stale
+ * field values
+ * (name, location, contextScopedLocation, tags, etc.) to survive across pool
+ * borrows
+ * under concurrent load, leading to NullPointerExceptions in the span tracking
+ * store.
+ */
+public class TraceComponentPoolTest {
+
+  private TraceComponentPool pool;
+
+  @Before
+  public void setUp() {
+    // onClose is invoked by PooledTraceComponent.close(); in these tests we call
+    // pool.release() directly, so a no-op callback is sufficient.
+    pool = new TraceComponentPool(component -> {
+    });
+    TraceComponentManager.resetForTest();
+  }
+
+  @After
+  public void tearDown() {
+    TraceComponentManager.resetForTest();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pool reset correctness
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void shouldClearAllFieldsOnReuse() {
+    // Given: a component is borrowed and fully populated
+    TraceComponent first = pool.acquire("tx-1", "my-flow");
+    first.withLocation("my-flow/processors/0")
+        .withEventContextId("ctx-abc123")
+        .withSpanName("GET /api")
+        .withSpanKind(SpanKind.SERVER)
+        .withStartTime(Instant.now())
+        .withEndTime(Instant.now())
+        .withTransactionId("tx-1");
+    first.addTag("key1", "value1");
+    first.addTag("key2", "value2");
+
+    // When: it is released and re-acquired
+    pool.release(first);
+    TraceComponent second = pool.acquire("tx-2", "other-flow");
+
+    // Then: all fields from the prior borrow must be gone
+    assertThat(second.getName()).as("name must be the new value").isEqualTo("other-flow");
+    assertThat(second.getTransactionId()).as("transactionId must be the new value").isEqualTo("tx-2");
+    assertThat(second.getLocation()).as("location must be null after reset").isNull();
+    assertThat(second.getEventContextId()).as("eventContextId must be null after reset").isNull();
+    assertThat(second.contextScopedLocation()).as("contextScopedLocation must be null after reset").isNull();
+    assertThat(second.getSpanName()).as("spanName must be null after reset").isNull();
+    assertThat(second.getSpanKind()).as("spanKind must be null after reset").isNull();
+    assertThat(second.getEndTime()).as("endTime must be null after reset").isNull();
+    assertThat(second.getContext()).as("context must be null after reset").isNull();
+    assertThat(second.getReadOnlyTags()).as("tags must be empty after reset").isEmpty();
+  }
+
+  @Test
+  public void shouldSetNameCorrectlyAfterReuseOfPreWarmedComponent() {
+    // The pool pre-warms 50 components with (null, null). Verify that after
+    // acquire the name is correctly set and not null.
+    TraceComponent component = pool.acquire("tx-1", "product-configs-api-gtwy-main");
+
+    assertThat(component.getName())
+        .as("name must not be null on a pre-warmed pool component")
+        .isEqualTo("product-configs-api-gtwy-main");
+    assertThat(component.getTransactionId())
+        .as("transactionId must not be null on a pre-warmed pool component")
+        .isEqualTo("tx-1");
+  }
+
+  // ---------------------------------------------------------------------------
+  // contextScopedLocation — ordering independence (Issue 2)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void shouldComputeContextScopedLocationWhenEventContextIdSetBeforeLocation() {
+    // This was the broken ordering: withEventContextId before withLocation
+    // Previously contextScopedLocation stayed null because the guard
+    // `if (getLocation() != null && contextScopedLocation == null)` skipped
+    // the computation when location was not yet set.
+    TraceComponent component = TraceComponent.of("my-flow", new HashMap<>())
+        .withEventContextId("ctx-abc123")
+        .withLocation("my-flow");
+
+    assertThat(component.contextScopedLocation())
+        .as("contextScopedLocation must be computed when eventContextId is set before location")
+        .isEqualTo("ctx-abc123/my-flow");
+  }
+
+  @Test
+  public void shouldComputeContextScopedLocationWhenLocationSetBeforeEventContextId() {
+    // This was always working; verify it still works after the fix
+    TraceComponent component = TraceComponent.of("my-flow", new HashMap<>())
+        .withLocation("my-flow")
+        .withEventContextId("ctx-abc123");
+
+    assertThat(component.contextScopedLocation())
+        .as("contextScopedLocation must be computed when location is set before eventContextId")
+        .isEqualTo("ctx-abc123/my-flow");
+  }
+
+  @Test
+  public void shouldRecomputeContextScopedLocationOnReuse() {
+    // Given: a component is borrowed, used, and returned to the pool
+    TraceComponent first = pool.acquire("tx-1", "flow-a");
+    first.withLocation("flow-a").withEventContextId("ctx-111");
+    assertThat(first.contextScopedLocation()).isEqualTo("ctx-111/flow-a");
+    pool.release(first);
+
+    // When: the same physical instance is re-acquired and configured for a
+    // different request
+    TraceComponent second = pool.acquire("tx-2", "flow-b");
+    second.withEventContextId("ctx-222").withLocation("flow-b");
+
+    // Then: contextScopedLocation must reflect the new values, not the prior
+    // borrow's values
+    assertThat(second.contextScopedLocation())
+        .as("contextScopedLocation must not carry stale value from prior borrow")
+        .isEqualTo("ctx-222/flow-b");
+  }
+
+  @Test
+  public void shouldNullContextScopedLocationWhenOnlyLocationSet() {
+    TraceComponent component = TraceComponent.of("my-flow", new HashMap<>())
+        .withLocation("my-flow");
+
+    assertThat(component.contextScopedLocation())
+        .as("contextScopedLocation must be null when eventContextId is not set")
+        .isNull();
+  }
+
+  @Test
+  public void shouldNullContextScopedLocationWhenOnlyEventContextIdSet() {
+    TraceComponent component = TraceComponent.of("my-flow", new HashMap<>())
+        .withEventContextId("ctx-abc123");
+
+    assertThat(component.contextScopedLocation())
+        .as("contextScopedLocation must be null when location is not set")
+        .isNull();
+  }
+
+  @Test
+  public void shouldNullContextScopedLocationWhenEventContextIdCleared() {
+    TraceComponent component = TraceComponent.of("my-flow", new HashMap<>())
+        .withLocation("my-flow")
+        .withEventContextId("ctx-abc123");
+
+    assertThat(component.contextScopedLocation()).isEqualTo("ctx-abc123/my-flow");
+
+    // Clearing the event context id must also null the scoped location
+    component.withEventContextId(null);
+    assertThat(component.contextScopedLocation())
+        .as("contextScopedLocation must be null after eventContextId is cleared")
+        .isNull();
+  }
+
+  @Test
+  public void shouldNullContextScopedLocationWhenLocationCleared() {
+    TraceComponent component = TraceComponent.of("my-flow", new HashMap<>())
+        .withLocation("my-flow")
+        .withEventContextId("ctx-abc123");
+
+    assertThat(component.contextScopedLocation()).isEqualTo("ctx-abc123/my-flow");
+
+    // Clearing location must also null the scoped location
+    component.withLocation(null);
+    assertThat(component.contextScopedLocation())
+        .as("contextScopedLocation must be null after location is cleared")
+        .isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // TraceComponentManager UUID-based tracking (Issue 5)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void shouldTrackAndUntrackComponentWhenLocationChangesAfterCreation() {
+    // This is the ghost entry bug: location changes after createTraceComponent,
+    // causing the old transactionId|location key to differ at close time.
+    // With UUID-based tracking, the key is immutable and close always removes
+    // the correct entry.
+    TraceComponentManager manager = TraceComponentManager.getInstance();
+    int initialCount = manager.getActiveComponentCount();
+
+    // Create a component with name only (no location at creation time)
+    TraceComponent component = manager.createTraceComponent("tx-ghost", "my-flow");
+    assertThat(manager.getActiveComponentCount())
+        .as("active count must increase after create")
+        .isEqualTo(initialCount + 1);
+
+    // Change the location after creation — this previously caused key mismatch
+    component.withLocation("my-flow/processors/0");
+
+    // Close the component — with UUID keys, this should remove the correct entry
+    component.close();
+    assertThat(manager.getActiveComponentCount())
+        .as("active count must return to initial after close, even with location change")
+        .isEqualTo(initialCount);
+  }
+
+  @Test
+  public void shouldTrackConcurrentComponentsWithSameTransactionIdAndLocationIndependently() {
+    // This is the double-tracking overwrite bug: two components with the same
+    // transactionId+location would share the same key, causing the second put()
+    // to overwrite the first. With UUID-based keys, each component has a unique
+    // key.
+    TraceComponentManager manager = TraceComponentManager.getInstance();
+    int initialCount = manager.getActiveComponentCount();
+
+    // Create two components with identical transactionId and name
+    TraceComponent comp1 = manager.createTraceComponent("tx-dup", "same-flow");
+    TraceComponent comp2 = manager.createTraceComponent("tx-dup", "same-flow");
+
+    assertThat(manager.getActiveComponentCount())
+        .as("both components must be tracked independently")
+        .isEqualTo(initialCount + 2);
+
+    // Close the first component — should not affect the second's tracking
+    comp1.close();
+    assertThat(manager.getActiveComponentCount())
+        .as("only one component removed after closing first")
+        .isEqualTo(initialCount + 1);
+
+    // Close the second component
+    comp2.close();
+    assertThat(manager.getActiveComponentCount())
+        .as("both components removed after closing both")
+        .isEqualTo(initialCount);
+  }
+
+  @Test
+  public void shouldTrackAndUntrackComponentCreatedWithLocation() {
+    // Verify normal tracking lifecycle for 3-arg createTraceComponent
+    // (transactionId, name, location) where location is later overridden.
+    TraceComponentManager manager = TraceComponentManager.getInstance();
+    int initialCount = manager.getActiveComponentCount();
+
+    // Use a mock-like ComponentLocation via the 2-arg name overload
+    // then override location — simulates
+    // FlowProcessorComponent.getStartTraceComponent
+    TraceComponent component = manager.createTraceComponent("tx-loc", "flow-name");
+    component.withLocation("flow-name"); // override to flow name like FlowProcessorComponent does
+
+    assertThat(manager.getActiveComponentCount())
+        .as("component must be tracked")
+        .isEqualTo(initialCount + 1);
+
+    component.close();
+    assertThat(manager.getActiveComponentCount())
+        .as("component must be untracked after close")
+        .isEqualTo(initialCount);
+  }
+
+  @Test
+  public void shouldRecomputeContextScopedLocationWhenLocationChanges() {
+    // Verify that calling withLocation twice recomputes contextScopedLocation
+    TraceComponent component = TraceComponent.of("flow", new HashMap<>())
+        .withEventContextId("ctx-1")
+        .withLocation("loc-a");
+    assertThat(component.contextScopedLocation()).isEqualTo("ctx-1/loc-a");
+
+    component.withLocation("loc-b");
+    assertThat(component.contextScopedLocation())
+        .as("contextScopedLocation must update when location changes")
+        .isEqualTo("ctx-1/loc-b");
+  }
+
+  @Test
+  public void shouldBeIdempotentOnDoubleClose() {
+    // Verify that calling close() twice doesn't cause errors or
+    // return the component to the pool twice
+    TraceComponentManager manager = TraceComponentManager.getInstance();
+    int initialCount = manager.getActiveComponentCount();
+
+    TraceComponent component = manager.createTraceComponent("tx-double", "my-flow");
+    assertThat(manager.getActiveComponentCount()).isEqualTo(initialCount + 1);
+
+    component.close();
+    assertThat(manager.getActiveComponentCount()).isEqualTo(initialCount);
+
+    // Second close should be a no-op
+    component.close();
+    assertThat(manager.getActiveComponentCount())
+        .as("double close must not cause negative tracking count")
+        .isEqualTo(initialCount);
+  }
+
+  @Test
+  public void shouldHandleConcurrentCreateAndClose() throws Exception {
+    // Stress test: many threads creating and closing components concurrently
+    // with location changes — verifying no ghost entries remain
+    TraceComponentManager manager = TraceComponentManager.getInstance();
+    int threads = 8;
+    int opsPerThread = 100;
+    ExecutorService executor = Executors.newFixedThreadPool(threads);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threads);
+    AtomicInteger errors = new AtomicInteger(0);
+
+    for (int t = 0; t < threads; t++) {
+      final int threadId = t;
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          for (int i = 0; i < opsPerThread; i++) {
+            try (TraceComponent tc = manager.createTraceComponent(
+                "tx-" + threadId + "-" + i, "flow-" + threadId)) {
+              // Simulate the real pattern: change location after creation
+              tc.withLocation("flow/proc/" + i);
+              tc.withEventContextId("ctx-" + threadId + "-" + i);
+            }
+          }
+        } catch (Exception e) {
+          errors.incrementAndGet();
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+    assertThat(doneLatch.await(30, TimeUnit.SECONDS))
+        .as("all threads must complete within timeout")
+        .isTrue();
+
+    assertThat(errors.get())
+        .as("no exceptions during concurrent create/close")
+        .isZero();
+
+    assertThat(manager.getActiveComponentCount())
+        .as("all components must be properly untracked after concurrent operations")
+        .isZero();
+
+    executor.shutdown();
+  }
+}

--- a/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStoreTest.java
+++ b/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/store/InMemoryTransactionStoreTest.java
@@ -1,6 +1,7 @@
 package com.avioconsulting.mule.opentelemetry.internal.store;
 
 import com.avioconsulting.mule.opentelemetry.api.config.ExporterConfiguration;
+import com.avioconsulting.mule.opentelemetry.api.traces.TransactionContext;
 import com.avioconsulting.mule.opentelemetry.api.config.OpenTelemetryResource;
 import com.avioconsulting.mule.opentelemetry.api.config.exporter.LoggingExporter;
 import com.avioconsulting.mule.opentelemetry.api.config.exporter.OpenTelemetryExporter;
@@ -28,6 +29,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.avioconsulting.mule.opentelemetry.api.store.TransactionStore.TRACE_TRANSACTION_ID;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -69,6 +71,43 @@ public class InMemoryTransactionStoreTest {
         tracer.spanBuilder(TEST_1_FLOW_FLOW_REF).setSpanKind(SpanKind.INTERNAL));
   }
 
+  /**
+   * Verifies that {@code endTransaction} does not throw a NullPointerException
+   * when the
+   * stored transaction has a null {@code rootSpanName} (e.g., caused by a pool
+   * reset race
+   * condition). With the {@code Objects.equals()} fix it must gracefully take the
+   * child-transaction branch instead of crashing.
+   */
+  @Test
+  public void endTransaction_doesNotThrowNPE_whenRootFlowNameIsNull() {
+    // Start a transaction with a null rootName to simulate a pool-race scenario
+    Instant startTimestamp = Instant.now();
+    SpanBuilder spanBuilder = tracer.spanBuilder("null-name-tx")
+        .setSpanKind(SpanKind.SERVER)
+        .setStartTimestamp(startTimestamp);
+    TraceComponent startComponent = TraceComponent.of(null, new HashMap<>())
+        .withTransactionId("null-name-tx")
+        .withSpanName("null-name-tx")
+        .withStartTime(startTimestamp)
+        .withLocation(TEST_1_FLOW_FLOW_REF)
+        .withEventContextId("null-name-ctx");
+    // startTransaction stores FlowTransaction with rootSpanName = null
+    connection.getTransactionStore().startTransaction(startComponent, null, spanBuilder);
+
+    // End event arrives with a non-null name
+    TraceComponent endComponent = TraceComponent.of(TEST_1_FLOW, new HashMap<>())
+        .withTransactionId("null-name-tx")
+        .withStartTime(startTimestamp)
+        .withEndTime(Instant.now())
+        .withLocation(TEST_1_FLOW_FLOW_REF)
+        .withEventContextId("null-name-ctx");
+
+    // Must not throw NullPointerException
+    assertThatCode(() -> connection.getTransactionStore().endTransaction(endComponent, span -> {
+    })).doesNotThrowAnyException();
+  }
+
   @Test
   public void endTransaction_return_new_tags_in_meta() {
     TraceComponent endTraceComponent = TraceComponent.of(TEST_1_FLOW, new HashMap<>()).withTransactionId("test-1")
@@ -86,6 +125,47 @@ public class InMemoryTransactionStoreTest {
     assertThat(transactionMeta).isNotNull()
         .extracting("tags", InstanceOfAssertFactories.map(String.class, String.class))
         .containsEntry("TEST_TAG_KEY", "test-tag-value");
+  }
+
+  /**
+   * H1: {@code addTransactionTags} must not throw when the transaction ID is
+   * unknown (i.e. the transaction was never started or has already been removed).
+   */
+  @Test
+  public void addTransactionTags_doesNotThrowNPE_whenTransactionNotFound() {
+    assertThatCode(() -> connection.getTransactionStore()
+        .addTransactionTags("non-existent-tx-id", "mule.app",
+            java.util.Collections.singletonMap("key", "value")))
+                .doesNotThrowAnyException();
+  }
+
+  /**
+   * H2: {@code getTransactionContext} with a {@code null} componentLocation must
+   * not throw when the transaction ID is unknown.
+   */
+  @Test
+  public void getTransactionContext_returnsFallbackContext_whenTransactionNotFoundAndComponentLocationIsNull() {
+    String txId = "non-existent-tx-id";
+    TransactionContext result = ((com.avioconsulting.mule.opentelemetry.internal.store.InMemoryTransactionStore) connection
+        .getTransactionStore()).getTransactionContext(txId, null);
+    assertThat(result).isNotNull();
+    assertThat(result.getTraceContextMap()).containsEntry(TRACE_TRANSACTION_ID, txId);
+  }
+
+  @Test
+  public void getTraceContext_returnsFallbackMap_whenTransactionNotFound() {
+    String txId = "missing-tx-id";
+    Map<String, Object> traceContext = connection.getTraceContext(txId);
+    assertThat(traceContext).isNotNull();
+    assertThat(traceContext).containsEntry(TRACE_TRANSACTION_ID, txId);
+  }
+
+  @Test
+  public void getTraceContext_withComponentLocation_returnsFallbackMap_whenTransactionNotFound() {
+    String txId = "missing-tx-id-with-location";
+    Map<String, Object> traceContext = connection.getTraceContext(txId, "flow/processors/0");
+    assertThat(traceContext).isNotNull();
+    assertThat(traceContext).containsEntry(TRACE_TRANSACTION_ID, txId);
   }
 
   private void processAPIKitRouterComponent() {

--- a/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/util/MDCUtilTest.java
+++ b/mule-module/src/test/java/com/avioconsulting/mule/opentelemetry/internal/util/MDCUtilTest.java
@@ -1,0 +1,96 @@
+package com.avioconsulting.mule.opentelemetry.internal.util;
+
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.runtime.api.event.Event;
+import org.mule.runtime.api.metadata.TypedValue;
+import org.slf4j.MDC;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.avioconsulting.mule.opentelemetry.api.store.TransactionStore.TRACE_CONTEXT_MAP_KEY;
+import static com.avioconsulting.mule.opentelemetry.api.store.TransactionStore.spanId;
+import static com.avioconsulting.mule.opentelemetry.api.store.TransactionStore.traceId;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MDCUtilTest {
+
+  @Before
+  public void setUp() {
+    MDC.clear();
+  }
+
+  @After
+  public void tearDown() {
+    MDC.clear();
+  }
+
+  @Test
+  public void replaceMDCOtelEntriesShouldReplaceTraceAndSpanIdsWhenContextContainsValidValues() {
+    Map<String, Object> context = new HashMap<>();
+    context.put(traceId, "5f9a6f7d22f5f292c9db9f8f1e23df0c");
+    context.put(spanId, "0af7651916cd43dd");
+
+    MDCUtil.replaceMDCOtelEntries(context);
+
+    Assertions.assertThat(MDC.get(MDCUtil.TRACE_ID)).isEqualTo("5f9a6f7d22f5f292c9db9f8f1e23df0c");
+    Assertions.assertThat(MDC.get(MDCUtil.SPAN_ID)).isEqualTo("0af7651916cd43dd");
+  }
+
+  @Test
+  public void replaceMDCOtelEntriesShouldNotReplaceExistingMdcWhenContextContainsInvalidValues() {
+    Map<String, Object> context = new HashMap<>();
+    context.put(traceId, TraceId.getInvalid());
+    context.put(spanId, SpanId.getInvalid());
+    MDC.put(MDCUtil.TRACE_ID, "existing-trace");
+    MDC.put(MDCUtil.SPAN_ID, "existing-span");
+
+    MDCUtil.replaceMDCOtelEntries(context);
+
+    Assertions.assertThat(MDC.get(MDCUtil.TRACE_ID)).isEqualTo("existing-trace");
+    Assertions.assertThat(MDC.get(MDCUtil.SPAN_ID)).isEqualTo("existing-span");
+  }
+
+  @Test
+  public void replaceMDCOtelEntriesFromVarsShouldReadContextFromMuleVariables() {
+    Map<String, Object> context = new HashMap<>();
+    context.put(traceId, "6f8a7f7d22f5f292c9db9f8f1e23df0d");
+    context.put(spanId, "1bf7651916cd43de");
+    Map<String, TypedValue<?>> variables = new HashMap<>();
+    variables.put(TRACE_CONTEXT_MAP_KEY, TypedValue.of(context));
+
+    MDCUtil.replaceMDCOtelEntriesFromVars(variables);
+
+    Assertions.assertThat(MDC.get(MDCUtil.TRACE_ID)).isEqualTo("6f8a7f7d22f5f292c9db9f8f1e23df0d");
+    Assertions.assertThat(MDC.get(MDCUtil.SPAN_ID)).isEqualTo("1bf7651916cd43de");
+  }
+
+  @Test
+  public void replaceMDCOtelEntriesWithEventShouldHandleNullEvent() {
+    MDCUtil.replaceMDCOtelEntries((Event) null);
+
+    Assertions.assertThat(MDC.getCopyOfContextMap()).isEmpty();
+  }
+
+  @Test
+  public void replaceMDCOtelEntriesWithEventShouldUseEventVariables() {
+    Map<String, Object> context = new HashMap<>();
+    context.put(traceId, "7f8a7f7d22f5f292c9db9f8f1e23df0e");
+    context.put(spanId, "2cf7651916cd43df");
+    Map<String, TypedValue<?>> variables = Collections.singletonMap(TRACE_CONTEXT_MAP_KEY, TypedValue.of(context));
+    Event event = mock(Event.class);
+    when(event.getVariables()).thenReturn(variables);
+
+    MDCUtil.replaceMDCOtelEntries(event);
+
+    Assertions.assertThat(MDC.get(MDCUtil.TRACE_ID)).isEqualTo("7f8a7f7d22f5f292c9db9f8f1e23df0e");
+    Assertions.assertThat(MDC.get(MDCUtil.SPAN_ID)).isEqualTo("2cf7651916cd43df");
+  }
+}


### PR DESCRIPTION
**What**
Improves OpenTelemetry tracing stability by adding null-safety protections and tightening pooled trace component cleanup behavior.

**Why**
Prevents edge-case runtime failures and ensures tracing remains resilient and non-disruptive when unexpected nulls or lifecycle timing issues occur.

**Changes**
- Added defensive null handling across tracing and transaction flows.
- Refined pooled trace component borrow/release/cleanup lifecycle behavior.
- Expanded test coverage to validate null-safety and pool cleanup scenarios.

Fixes #303 

Supersedes #304  